### PR TITLE
Feature/auto nsid

### DIFF
--- a/server/bin/nt_export.pl
+++ b/server/bin/nt_export.pl
@@ -75,6 +75,12 @@ $dsn     ||= ask( "database DSN",
 $db_user ||= ask( "database user", default => 'root' );
 $db_pass ||= ask( "database pass", password => 1 );
 
+# If nsid has not be specified, try to locate the nsid for this server,
+# or display a table of nsid to use to generate the zone files.
+if ( !defined $nsid ) {
+    $nsid = get_nsid();
+}
+
 my $export = NicToolServer::Export->new( 
     ns_id => $nsid || 0,
     force => $force || 0,
@@ -84,8 +90,6 @@ my $export = NicToolServer::Export->new(
 $export->incremental( $incremental || 0);
 $export->get_dbh( dsn => $dsn, user => $db_user, pass => $db_pass,) 
     or die "database connection failed";
-
-defined $nsid || get_nsid();
 
 local $SIG{HUP}  = \&graceful_exit;
 local $SIG{TERM} = \&graceful_exit;

--- a/server/bin/nt_export.pl
+++ b/server/bin/nt_export.pl
@@ -10,6 +10,7 @@ use lib '../server/lib';
 #use Data::Dumper;
 use Getopt::Long;
 use Params::Validate qw/:all/;
+use Sys::Hostname;
 #$Data::Dumper::Sortkeys=1;
 
 use NicToolServer::Export;
@@ -100,6 +101,15 @@ exit 0;
 
 sub get_nsid {
     my $nslist = $export->get_active_nameservers();
+    
+    # determine if the current hostname is a listed nameserver
+    my $me = &hostname;
+    foreach my $nsentry (@$nslist) {
+        if ($nsentry->{name} =~ /^$me\./) {
+            return $nsentry->{nt_nameserver_id};
+        }
+    }
+    
     printf( "\n%5s   %25s   %9s\n", 'nsid', 'name', 'format' );
     my $format = "%5.0f   %25s   %9s\n";
     foreach my $ns (sort @$nslist) {

--- a/server/bin/nt_export.pl
+++ b/server/bin/nt_export.pl
@@ -85,11 +85,10 @@ $export->incremental( $incremental || 0);
 $export->get_dbh( dsn => $dsn, user => $db_user, pass => $db_pass,) 
     or die "database connection failed";
 
-# If nsid has not be specified, try to locate the nsid for this server,
+# If nsid has not been specified, try to locate the nsid for this server,
 # or display a table of nsid to use to generate the zone files.
 if ( !defined $nsid ) {
-    $nsid = get_nsid($export);
-    $export->{ns_id} = $nsid;
+    $nsid = $export->{ns_id} = get_nsid($export);
     $export->set_active_nameserver($nsid);
 }
 

--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -613,8 +613,7 @@ LEFT JOIN nt_nameserver_export_type et ON ns.export_type_id=et.id
     }
 
     if ( $self->{ns_id} ) {
-        $self->{ns_ref} = $self->{active_ns_ids}{$self->{ns_id}};
-        $self->{export_format} = $self->{ns_ref}{export_format};
+        $self->set_active_nameserver($self->{ns_id});
     }
     else {
         my $first = $self->{active_ns_ids}{ $self->{active_ns}[0] } ||
@@ -623,6 +622,14 @@ LEFT JOIN nt_nameserver_export_type et ON ns.export_type_id=et.id
     };
 
     return $self->{active_ns};
+}
+
+sub set_active_nameserver {
+    my $self = shift;
+    my $nsid = shift;
+    
+    $self->{ns_ref} = $self->{active_ns_ids}{$nsid};
+    $self->{export_format} = $self->{ns_ref}{export_format};  
 }
 
 sub load_export_class {


### PR DESCRIPTION
Allow the nsid parameter to nt_export.pl to be auto discovered if nt_export.pl is being executed on a host that is already registered as a nameserver. 