### PR TITLE
Feature/export detect

### DIFF
--- a/server/bin/nt_export.pl
+++ b/server/bin/nt_export.pl
@@ -93,10 +93,12 @@ local $SIG{USR1} = \&graceful_exit;
 local $SIG{SEGV} = \&graceful_exit;
 local $SIG{ALRM} = \&graceful_exit;
 
+my $result;
 if ( $daemon ) { $export->daemon(); }
-else           { $export->export(); };
+else           { $result = $export->export(); };
 
-exit 0;
+exit $result;
+
 
 sub get_nsid {
     my $nslist = $export->get_active_nameservers();

--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -52,7 +52,7 @@ sub new {
 
 sub daemon {
     my $self = shift;
-    $self->export();
+    my $result = $self->export();
     my $end = time;
     my $waitleft = 60;
     if ( defined $self->{ns_ref}{export_interval} ) {
@@ -65,6 +65,7 @@ sub daemon {
         sleep 1;
         $waitleft--;
     };
+    return $result;
 };
 
 sub elog {

--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -127,7 +127,7 @@ sub set_no_change {
 
     $self->set_status("last run:$last_ts<br>last cp :$last_cp_ts");
     $self->elog("exiting\n",success=>1);
-    return 1;
+    return 0;
 };
 
 sub set_partial {
@@ -217,6 +217,8 @@ sub exec_query {
     return $r;
 }
 
+# export() now returns state of an export. If no export occured, then
+# it will return 0. Otherwise it return 1 when an export does occur.
 sub export {
     my $self = shift;
 
@@ -238,7 +240,7 @@ sub export {
     if ( (time - $before) > 5 ) { $elapsed = ' ('. (time - $before) . ' secs)' };
     $self->elog('exported'.$elapsed);
 
-    $self->postflight or return;
+    $self->postflight;
     return 1;
 }
 

--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -235,7 +235,7 @@ sub export {
 
     my $before = time;
     $self->set_status("exporting from DB");
-    $self->{export_class}->export_db() or return;
+    $self->{export_class}->export_db() or return 0;
     my $elapsed = '';
     if ( (time - $before) > 5 ) { $elapsed = ' ('. (time - $before) . ' secs)' };
     $self->elog('exported'.$elapsed);


### PR DESCRIPTION
One more to make it easy to detect when an export actually occurs and trigger rndc reload. Comments added to NicToolServer::Export::export() summarized pretty much everything. 

```perl
# export() now returns state of an export. If no export occured, then
# it will return 0. Otherwise it return 1 when an export does occur.
```

NicToolServer::Export::daemon() also updated to return the exported status also. 

Usage text updated to explain new functionality. Typical usage would be something like the following added to cron:

```shell
(cd /var/named; /usr/local/nictool/server/bin/nt_export.pl; [[ $? == 1 ]] && /sbin/rndc reload) >/dev/null 2>&1
```