### PR TITLE
Initial LDAP support.

### DIFF
--- a/server/lib/NicToolServer/Session.pm
+++ b/server/lib/NicToolServer/Session.pm
@@ -50,7 +50,7 @@ sub verify_login {
 
     return $self->auth_error('invalid password')
         if (! $self->valid_password( $pass_attempt, $user->{password},
-              $data->{username}, $user->{pass_salt} ));
+              $data->{username}, $data->{groupname}, $user->{pass_salt}, $user->{ldap_user} ));
 
     $self->clean_user_data;
 

--- a/server/lib/NicToolServer/User.pm
+++ b/server/lib/NicToolServer/User.pm
@@ -619,13 +619,12 @@ sub valid_password {
         load('Net::LDAP::Util', 'ldap_error_text');
 
         my @servers = split(',', $self->get_option('ldap_servers'));
-        die Dumper(@servers);
         my $starttls_required = $self->get_option('ldap_starttls');
         my $bindDN = $self->get_option('ldap_binddn');
         my $bindDN_password = $self->get_option('ldap_bindpw');
         my $baseDN = $self->get_option('ldap_basedn');
-        my $filter = $self->get_option('ldap_filter') || '(&(uid=%uid))';
-        my $user_mapping = $self->get_option('ldap_user_mapping') || 'uid';
+        my $filter = $self->get_option('ldap_filter');
+        my $user_mapping = $self->get_option('ldap_user_mapping');
         my $group_mapping = $self->get_option('ldap_group_mapping');
 
         my $ldap = Net::LDAP->new(@servers, version => 3) or die 'LDAP: Error in Net::LDAP.';


### PR DESCRIPTION
This implements support for LDAP. A new columnn in nt_user is required (ldap_user) with a DEFAULT value of 0. This acts as a trigger for ldap authentication. The following new rows now should exist in nt_options: (with example values filled in). These values as described here should be the default ones in the new db schema, especially starttls.

# option_id, option_name, option_value
'5', 'ldap_servers', 'ldap://ldap.example.com'
'6', 'ldap_starttls', '1'
'7', 'ldap_binddn', 'uid=binduser,o=example,c=com'
'8', 'ldap_bindpw', 'password'
'9', 'ldap_basedn', 'ou=People,o=example,c=com'
'10', 'ldap_filter', '(uid=*)'
'11', 'ldap_user_mapping', 'uid'
