### PR TITLE
Basic ldap support - v2

### DIFF
--- a/server/dist.ini
+++ b/server/dist.ini
@@ -69,3 +69,4 @@ Mozilla::CA            = 1
 ; used by NicToolServer::Import::BIND
 Net::DNS::Zone::Parser = 1
 BIND::Conf_Parser      = 1
+Net::LDAP              = 0.65

--- a/server/lib/NicToolServer.pm
+++ b/server/lib/NicToolServer.pm
@@ -25,6 +25,7 @@ sub new {
 }
 
 sub debug             {0}
+sub debug_auth        {0}
 sub debug_session_sql {0}
 sub debug_sql         {0}
 sub debug_permissions {0}

--- a/server/lib/nictoolserver.conf.dist
+++ b/server/lib/nictoolserver.conf.dist
@@ -26,9 +26,24 @@ use NicToolServer::Nameserver;
 use NicToolServer::Nameserver::Sanity;
 
 BEGIN {
-    $NicToolServer::dsn = "DBI:mysql:database=nictool;host=127.0.0.1;port=3306";
-    $NicToolServer::db_user     = 'nictool';
-    $NicToolServer::db_pass     = 'lootcin205';
+    # Database configuration
+    $NicToolServer::dsn     = "DBI:mysql:database=nictool;host=127.0.0.1;port=3306";
+    $NicToolServer::db_user = 'nictool';
+    $NicToolServer::db_pass = 'lootcin205';
+
+    # LDAP configuration
+    # $NicToolServer::ldap_servers  = 'ldap1.example.com,ldap2.example.com'; # Comma-separated list
+    # $NicToolServer::ldap_starttls = 0;                                     # Defaults to 0
+    # $NicToolServer::ldap_basedn   = 'ou=Nictool users,dc=example,dc=com';  # Search base
+    # $NicToolServer::ldap_user_mapping = 'uid';                             # Defaults to 'uid'
+
+    # If ldap_filter is set, NicTool will perform a subtree search (scope: sub) for user under ldap_basedn, 
+    # otherwise it will guesstimate the dn at basedn level (ala scope: one)
+    # $NicToolServer::ldap_filter = '(&(objectClass=*)(uid=*))';
+
+    # If anonymous search for the user_mapping attribute is not allowed. Only needed if filter is defined
+    # $NicToolServer::ldap_binddn = 'cn=Admin,dc=example,dc=com';
+    # $NicToolServer::ldap_bindpw = 'the_admin_password';
 
     Apache::DBI->connect_on_init($NicToolServer::dsn, $NicToolServer::db_user, $NicToolServer::db_pass);
 }


### PR DESCRIPTION
The patch implements a simple sequential login scheme ala PAM. When a user logs in, the code checks each password scheme for a match, eventually falling back to a ldap directory password check if so configured. This means that the patch will work as is without any additional database schema or gui changes. 

The code builds on the latest pull request from vtsingaras. Most of the ldap-authentication code is his, but I have changed the failure modes to graceful failed-login attempts instead. LDAP group based login is not supported in this patch.

At some future point, the database should contain an inkling of whether the user is LDAP based or not, so e.g. the edit-user dialogues can hide passwods etc. 