### PR TITLE
Honour FQDN . on A and CNAME entries for @ type records

### DIFF
--- a/server/lib/NicToolServer/Export/BIND/nsupdate.pm
+++ b/server/lib/NicToolServer/Export/BIND/nsupdate.pm
@@ -221,13 +221,11 @@ sub zr_a {
             . $r->{name}
             . " $r->{ttl} A $r->{address}\n";
     }
-    else {
-        return
-              "update $mode "
-            . $r->{name} . "."
-            . $r->{zone}
-            . " $r->{ttl} A $r->{address}\n";
-    }
+    return
+          "update $mode "
+        . $r->{name} . "."
+        . $r->{zone}
+        . " $r->{ttl} A $r->{address}\n";
 }
 
 sub zr_cname {
@@ -241,13 +239,11 @@ sub zr_cname {
             . $r->{name}
             . " $r->{ttl} CNAME $r->{address}\n";
     }
-    else {
-        return
-              "update $mode "
-            . $r->{name} . "."
-            . $r->{zone}
-            . " $r->{ttl} CNAME $r->{address}\n";
-    }
+    return
+          "update $mode "
+        . $r->{name} . "."
+        . $r->{zone}
+        . " $r->{ttl} CNAME $r->{address}\n";
 }
 
 sub zr_mx {

--- a/server/lib/NicToolServer/Export/BIND/nsupdate.pm
+++ b/server/lib/NicToolServer/Export/BIND/nsupdate.pm
@@ -215,11 +215,19 @@ sub zr_a {
     $mode = "add" unless defined($mode);
     $r->{zone} = $self->{nte}->{zone_name} unless defined( $r->{zone} );
 
-    return
-          "update $mode "
-        . $r->{name} . "."
-        . $r->{zone}
-        . " $r->{ttl} A $r->{address}\n";
+    if ($r->{name} =~ m/\.$/) {
+        return
+              "update $mode "
+            . $r->{name}
+            . " $r->{ttl} A $r->{address}\n";
+    }
+    else {
+        return
+              "update $mode "
+            . $r->{name} . "."
+            . $r->{zone}
+            . " $r->{ttl} A $r->{address}\n";
+    }
 }
 
 sub zr_cname {
@@ -227,11 +235,19 @@ sub zr_cname {
     $mode = "add" unless defined($mode);
     $r->{zone} = $self->{nte}->{zone_name} unless defined( $r->{zone} );
 
-    return
-          "update $mode "
-        . $r->{name} . "."
-        . $r->{zone}
-        . " $r->{ttl} CNAME $r->{address}\n";
+    if ($r->{name} =~ m/\.$/) {
+        return
+              "update $mode "
+            . $r->{name}
+            . " $r->{ttl} CNAME $r->{address}\n";
+    }
+    else {
+        return
+              "update $mode "
+            . $r->{name} . "."
+            . $r->{zone}
+            . " $r->{ttl} CNAME $r->{address}\n";
+    }
 }
 
 sub zr_mx {


### PR DESCRIPTION
CNAME type entries dont work and are ignored by nsupdate, but this will stop them generating other entries anyway.

A record entries will work as expected after this update.

If further changes are required for NS / MX / other entries i'll make another pull req when i have adjusted for that after testing.