### PR TITLE
Fixed issue with Export Format for new nameserver.

### DIFF
--- a/client/htdocs/group_nameservers.cgi
+++ b/client/htdocs/group_nameservers.cgi
@@ -568,7 +568,7 @@ sub display_edit_nameserver_fields {
                         -name    => 'export_format',
                         -values  => $export_format_values,
                         -labels  => $export_format_labels,
-                        -default => $nameserver->{export_format} || $q->param('export_format'),
+                        -default => $nameserver->{export_format} || $q->param('export_format') || 'bind',
                         -onChange => "changeNSExportType(value);",
                         -required  => 'required',
                         )


### PR DESCRIPTION
in nictool, when you click "nameservers" then select a name server, the "Export Format:" causes javascript to change the link next to it as well as the "Remote Login". 

However, when you click  "nameservers" then "new nameserver", the drop down doesnt function with the javascript. 

This patch fixes that problem, from our internal git branch of nictool.