### PR TITLE
Since Net::DNS::Zone::Parser expands all records to include their

### DIFF
--- a/server/lib/NicToolServer/Import/BIND.pm
+++ b/server/lib/NicToolServer/Import/BIND.pm
@@ -255,7 +255,7 @@ sub zr_dname {
     );
 }
 
-sub zr_sshfp { 
+sub zr_sshfp {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
@@ -273,7 +273,7 @@ sub zr_sshfp {
     );
 };
 
-sub zr_naptr { 
+sub zr_naptr {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
@@ -288,7 +288,7 @@ sub zr_naptr {
         weight  => $rr->order,
         priority=> $rr->preference,
         ttl     => $rr->ttl,
-        description=>$rr->replacement,
+        description=> $self->fully_qualify( $rr->replacement ),
     );
 };
 
@@ -308,7 +308,7 @@ sub zr_ptr {
     );
 };
 
-sub zr_ipseckey { 
+sub zr_ipseckey {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 

--- a/server/lib/NicToolServer/Import/Base.pm
+++ b/server/lib/NicToolServer/Import/Base.pm
@@ -141,7 +141,7 @@ sub nt_create_record {
     my %request = (
         nt_zone_id => $p{zone_id},
         name       => lc $p{name},
-        address    => lc $p{address},
+        address    => ($p{type} eq 'NAPTR' ? $p{address} : lc $p{address}),
         type       => $p{type},
     );
 


### PR DESCRIPTION
Since Net::DNS::Zone::Parser expands all records to include their
$ORIGIN - we also need to add a . to the end of NAPTR records.

Currently the import without a dot, so the result is:
record.$ORIGIN.$ORIGIN
