### PR TITLE
Add ldap_only option

### DIFF
--- a/client/htdocs/group_users.cgi
+++ b/client/htdocs/group_users.cgi
@@ -151,13 +151,16 @@ sub display_edit_user {
     my $tr = '<tr class=light_grey_bg><td class=right>';
     print qq[
 <table class="fat">
- <tr class=dark_bg><td colspan=2><b>New User</b></td></tr>
- $tr Username:</td><td class=width80>$username</td></tr>
- $tr First Name:</td><td class=width80>$firstname</td></tr>
- $tr Last Name:</td><td class=width80>$lastname</td></tr>
- $tr Email Address:</td><td class=width80>$email</td></tr>
- $tr Password:</td><td class=width80>$password</td></tr>
+ <tr class="dark_bg"><td colspan="2"><b>New User</b></td></tr>
+ $tr Username:</td><td class="width80">$username</td></tr>
+ $tr First Name:</td><td class="width80">$firstname</td></tr>
+ $tr Last Name:</td><td class="width80">$lastname</td></tr>
+ $tr Email Address:</td><td class="width80">$email</td></tr>];
+ if (! $user->{ldap_only}) {
+     print qq[
+ $tr Password:</td><td class="width80">$password</td></tr>
  $tr Password (Again):</td><td style="width:80%;">$password2</td></tr>];
+ }
 
     display_user_permissions( $nt_obj, $q, $group, $user );
 

--- a/client/htdocs/user.cgi
+++ b/client/htdocs/user.cgi
@@ -65,8 +65,13 @@ sub display {
 
         my ( $error, %data );
         my @fields = qw/ user_create user_delete user_write group_create group_delete group_write zone_create zone_delegate zone_delete zone_write zonerecord_create zonerecord_delegate zonerecord_delete zonerecord_write nameserver_create nameserver_delete nameserver_write self_write /;
-        my @new_fields  = qw/ nt_group_id username first_name last_name email password password2 /;
-        my @edit_fields = qw/ nt_user_id username first_name last_name email password password2 current_password/;
+        my @new_fields  = qw/ nt_group_id username first_name last_name email /;
+        my @edit_fields = qw/ nt_user_id username first_name last_name email /;
+
+        if (! $user->{'ldap_only'} ) {
+            push @new_fields, qw/ password password2 /;
+            push @new_fields, qw/ password password2 current_password /;
+        }
 
         #warn "group_defaults is ".$q->param('group_defaults');
         if ( $q->param('group_defaults') eq '0' ) {
@@ -441,29 +446,37 @@ sub display_edit {
     </tr>";
 
     if ($modifyperm) {
-        if ( ! $user->{is_admin} ) {    # note that is_admin is global
-        print qq[<tr class="dark_grey_bg"><td colspan="2">Change Password</td></tr>
-<tr class="light_grey_bg">
-<td class="right nowrap">Current Password:</td>
-<td class="fat">],
-            $q->password_field( -name => 'current_password', -override => 1 ),
-            qq[</td>
-</tr>];
-        };
 
-        print qq[<tr class="light_grey_bg"><td colspan="2">&nbsp;</td></tr>
-<tr class="light_grey_bg">
-<td class="right nowrap">New Password:</td>
-<td class="fat">],
-            $q->password_field( -name => 'password', -size=>15, -maxlength => 30, -override  => 1),
-            qq[</td>
-</tr>
+        if ( $user->{ldap_only} ) {
+
+        	   print qq[<tr class="dark_grey_bg"><td colspan="2">Change Password</td></tr>
+        	   <tr class="light_grey_bg"><td colspan="2">All password in LDAP</td></tr>];
+        }
+        else {
+
+                if ( ! $user->{is_admin} ) {    # note that is_admin is global
+        	   print qq[<tr class="dark_grey_bg"><td colspan="2">Change Password</td></tr>
+        <tr class="light_grey_bg">
+            <td class="right nowrap">Current Password:</td>
+            <td class="fat">],
+        	   $q->password_field( -name => 'current_password', -override => 1 ),
+        	   q[</td></tr>];
+        	};
+
+        	print qq[<tr class="light_grey_bg"><td colspan="2">&nbsp;</td></tr>
+        <tr class="light_grey_bg">
+        	<td class="right nowrap">New Password:</td>
+        	<td class="fat">],
+        	 $q->password_field( -name => 'password', -size=>15, -maxlength => 30, -override  => 1),
+                 qq[</td></tr>
 <tr class="light_grey_bg">
 <td class="right nowrap">Confirm New Password:</td>
 <td class="fat">],
-            $q->password_field( -name => 'password2', -size=>15, -maxlength => 30, -override  => 1),
-            qq[</td>
-        </tr>];
+        	  $q->password_field( -name => 'password2', -size=>15, -maxlength => 30, -override  => 1),
+        	  q[</td></tr>];
+
+        }
+
     }
 
     if ($showpermissions) {

--- a/server/lib/NicToolServer.pm
+++ b/server/lib/NicToolServer.pm
@@ -109,6 +109,49 @@ sub ver_check {
 
 sub api_commands {
     my $self = shift;
+
+    my %new_user;
+
+    if ($NicToolServer::ldap_only) {
+
+        %new_user = (
+
+            'new_user' => {
+                'class'      => 'User::Sanity',
+                'method'     => 'new_user',
+                'creation'   => 'USER',
+                'parameters' => {
+                    'nt_group_id' =>
+                         { 'access' => 'read', required => 1, type => 'GROUP' },
+                    'username'  => { required => 1 },
+                    'email'     => { required => 1 },
+                },
+            },
+
+        );
+
+    }
+    else {
+        %new_user = (
+
+            'new_user' => {
+                'class'      => 'User::Sanity',
+                'method'     => 'new_user',
+                'creation'   => 'USER',
+                'parameters' => {
+                    'nt_group_id' =>
+                         { 'access' => 'read', required => 1, type => 'GROUP' },
+                    'username'  => { required => 1 },
+                    'email'     => { required => 1 },
+                    'password'  => { required => 1 },
+                    'password2' => { required => 1 },
+                },
+            },
+
+        );
+
+    }
+
     return {
 
         # user API
@@ -118,19 +161,6 @@ sub api_commands {
             'parameters' => {
                 'nt_user_id' =>
                     { access => 'read', required => 1, type => 'USER' },
-            },
-        },
-        'new_user' => {
-            'class'      => 'User::Sanity',
-            'method'     => 'new_user',
-            'creation'   => 'USER',
-            'parameters' => {
-                'nt_group_id' =>
-                    { 'access' => 'read', required => 1, type => 'GROUP' },
-                'username'  => { required => 1 },
-                'email'     => { required => 1 },
-                'password'  => { required => 1 },
-                'password2' => { required => 1 },
             },
         },
         'edit_user' => {
@@ -148,6 +178,7 @@ sub api_commands {
                 },
             },
         },
+        %new_user,
         'delete_users' => {
             'class'      => 'User',
             'method'     => 'delete_users',

--- a/server/lib/NicToolServer/Session.pm
+++ b/server/lib/NicToolServer/Session.pm
@@ -201,6 +201,8 @@ sub verify_session {
 
     $self->clean_user_data;
 
+    $data->{user}{ldap_only} = $NicToolServer::ldap_only || 0;
+
     return 0;
 }
 

--- a/server/lib/NicToolServer/User.pm
+++ b/server/lib/NicToolServer/User.pm
@@ -95,8 +95,14 @@ sub new_user {
 
     my @columns = qw/nt_group_id first_name last_name username email password pass_salt/;
 
-    $data->{pass_salt} = $self->_get_salt();
-    $data->{password} = $self->get_pbkdf2_hash($data->{password}, $data->{pass_salt});
+    if ($self->{user}->{ldap_only}) {
+        $data->{pass_salt} = 'ldap_only';
+        $data->{password} = 'ldap_only';
+    }
+    else {
+        $data->{pass_salt} = $self->_get_salt();
+        $data->{password} = $self->get_pbkdf2_hash($data->{password}, $data->{pass_salt});
+    }
 
     my $sql
         = "INSERT INTO nt_user("
@@ -613,20 +619,24 @@ sub log_user {
 sub valid_password {
     my ($self, $attempt, $db_pass, $user, $salt) = @_;
 
-    # Check for PBKDF2 password
-    if ( $salt ) {
-        my $hashed = $self->get_pbkdf2_hash($attempt, $salt);
-        return 1 if $hashed eq $db_pass;
-    };
+    if ( ! $NicToolServer::ldap_only ) {
 
-    # Check for HMAC SHA-1 password
-    if ( $db_pass =~ /[0-9a-f]{40}/ ) {        # DB has HMAC SHA-1 hash
-        my $hashed = $self->get_sha1_hash($attempt, $user);
-        return 1 if $hashed eq $db_pass;
+        # Check for PBKDF2 password
+        if ( $salt ) {
+            my $hashed = $self->get_pbkdf2_hash($attempt, $salt);
+            return 1 if $hashed eq $db_pass;
+        };
+
+        # Check for HMAC SHA-1 password
+        if ( $db_pass =~ /[0-9a-f]{40}/ ) {        # DB has HMAC SHA-1 hash
+            my $hashed = $self->get_sha1_hash($attempt, $user);
+            return 1 if $hashed eq $db_pass;
+        }
+
+        # Check for Plain password
+        return 1 if ( ! $salt && $attempt eq $db_pass );   # plain password
+
     }
-
-    # Check for Plain password
-    return 1 if ( ! $salt && $attempt eq $db_pass );   # plain password
 
     # If LDAP is defined - check for LDAP based user
     if ( $NicToolServer::ldap_servers ) {

--- a/server/lib/NicToolServer/User/Sanity.pm
+++ b/server/lib/NicToolServer/User/Sanity.pm
@@ -14,7 +14,8 @@ sub new_user {
 
     $self->_valid_username($data);
     $self->_valid_email($data);
-    $self->_valid_password($data);
+    $self->_valid_password($data)
+        unless $self->{user}->{ldap_only};
 
     return $self->throw_sanity_error if $self->{errors};
     $self->SUPER::new_user($data);

--- a/server/lib/nictoolserver.conf.dist
+++ b/server/lib/nictoolserver.conf.dist
@@ -36,8 +36,9 @@ BEGIN {
     # $NicToolServer::ldap_starttls = 0;                                     # Defaults to 0
     # $NicToolServer::ldap_basedn   = 'ou=Nictool users,dc=example,dc=com';  # Search base
     # $NicToolServer::ldap_user_mapping = 'uid';                             # Defaults to 'uid'
+    # $NicToolServer::ldap_only = 1;                                         # Defaults to 0
 
-    # If ldap_filter is set, NicTool will perform a subtree search (scope: sub) for user under ldap_basedn, 
+    # If ldap_filter is set, NicTool will perform a subtree search (scope: sub) for user under ldap_basedn,
     # otherwise it will guesstimate the dn at basedn level (ala scope: one)
     # $NicToolServer::ldap_filter = '(&(objectClass=*)(uid=*))';
 


### PR DESCRIPTION
Currently, passwords will come out of the local database OR ldap.
This is sort of insane, but people might want it. So add an option
called ldap_only which makes passwords only come from LDAP.

This is also communicated to the client, which then hides the options
to edit passwords.

Users created have meaningless password and salt values inserted into
the database so that changing ldap_only will render their accounts
locked out.
