### PR TITLE
Group-less login

### DIFF
--- a/server/lib/NicToolServer/Session.pm
+++ b/server/lib/NicToolServer/Session.pm
@@ -249,12 +249,31 @@ sub populate_groups {
         );
     }
     else {
-        my $default_group = $self->get_option('default_group') || 'NicTool';
 
-        $ids = $self->exec_query(
-            "SELECT nt_group_id FROM nt_group WHERE deleted=0 AND name IN (?)",
-            [$default_group],
+        my $temp = $self->exec_query(
+            q/ SELECT ntu.nt_group_id
+                FROM nt_user AS ntu
+                LEFT JOIN nt_group AS ntg
+                    ON ntu.nt_group_id = ntg.nt_group_id
+                WHERE 1=1
+                    AND ntg.deleted = 0
+                    AND ntu.username = ?
+                -- /,
+            $data->{username}
         );
+
+        if (@$temp == 1) {
+            $ids = $temp
+        }
+        else { # more than one user or none
+
+            $ids = $self->exec_query(
+                q/ SELECT nt_group_id FROM nt_group WHERE deleted=0 AND name IN (?) -- /,
+                [$self->get_option('default_group') || 'NicTool' ]
+            );
+
+        }
+
     }
 
     foreach (@$ids) {


### PR DESCRIPTION
If there is only one username, pick out which group its in and use that.

So people dont have to worry about user@group if they are in one group
but its not the default group.

With ldap, usernames are globally unique so group-unique usernames
aren't possible anyway.

Downside is that if a second user is added, they will have to start adding @group to their username without warning 
