### PR TITLE
Remove comments form end of line

### DIFF
--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -36,6 +36,11 @@ sub import_records {
         next if $record =~ /^#/;     # comment
         next if $record =~ /^\s+$/;  # blank line
         next if $record =~ /^\-/;    # IGNORE: - fqdn : ip : ttl:timestamp:lo
+		#
+		 #PTO Remove Comments from end of lines 
+        if($record =~ m/(\S+)\s+\#.*/) { $record = $1; }
+
+		
         Time::HiRes::sleep 0.1;      # go slow enough we can read
 
         my $first = substr($record, 0, 1);


### PR DESCRIPTION
The TinyDNS import breaks if an in-line comment exists. 
Example which breaks the import:
+speedtest.telenor.dk:1.2.3.4    #Comment