### PR TITLE
Added https support for nt_import and NicToolServer::Import::Base

### DIFF
--- a/server/bin/nt_import.pl
+++ b/server/bin/nt_import.pl
@@ -22,6 +22,7 @@ Getopt::Long::GetOptions(
     'file=s'    => \my $filename,
     'user=s'    => \my $nt_user,
     'pass=s'    => \my $nt_pass,
+    'use-https' => \my $nt_https,
     'type=s'    => \my $type,
     'verbose'   => \my $verbose,
     'help'      => \my $help,
@@ -38,6 +39,7 @@ if($help) {
      print "  --type           Import type (tinydns or bind)\n";
      print "  --file           File to import data from (data for tinydns, named.conf for bind)\n";
      print "  --group_id       NicTool group id zones are placed into\n";
+     print "  --use-https      Use https towards NicTool Server\n";
      print "  --verbose        Show extra messages verbose\n\n";
      print "Report issues at https://github.com/msimerson/NicTool/issues\n";
      exit 0;
@@ -49,7 +51,7 @@ $nt_pass ||= ask( "NicTool user password", password => 1 ) if ! $nt_pass;
 
 my $nti;
 $type ||= get_type(); load_type($type);
-my $nt = $nti->nt_connect($nt_host, $nt_port, $nt_user, $nt_pass);
+my $nt = $nti->nt_connect($nt_host, $nt_port, $nt_user, $nt_pass, $nt_https);
 
 $group_id ||= $nt->result->{store}{nt_group_id} || die "unable to get group ID\n";
 warn Dumper($nt->result->{store}) if $verbose;

--- a/server/lib/NicToolServer/Import/Base.pm
+++ b/server/lib/NicToolServer/Import/Base.pm
@@ -19,6 +19,7 @@ sub new {
             nt_pass     => undef,
             group_id    => undef,
             nameservers => undef,
+            nt_https    => 0,
         }, $class;
     return $self;
 };
@@ -279,7 +280,7 @@ sub nt_get_zone_records {
 }
 
 sub nt_connect {
-    my ($self, $nt_host, $nt_port, $nt_user, $nt_pass) = @_;
+    my ($self, $nt_host, $nt_port, $nt_user, $nt_pass, $nt_https) = @_;
 
     return $self->{nt} if $self->{nt};
 
@@ -298,6 +299,7 @@ sub nt_connect {
     my $nt = NicTool->new(
             server_host => $nt_host || '127.0.0.1',
             server_port => $nt_port || 8082,
+            transfer_protocol => $nt_https ? 'https' : 'http',
 #protocol    => 'xml_rpc',  # or soap
             );
 


### PR DESCRIPTION
Minor update adding support to nt_import for using https towards a NicTool server. Added: 
* use-https commandline option to nt_import
* support for a $nt_https parameter in NicToolServer::Import::Base::nt_connect function