### PR TITLE
fix unset record type upon form presentation

### DIFF
--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -814,7 +814,7 @@ sub display_edit_record {
         && $user->{'zonerecord_write'}
         && $zone_record->{'delegate_write'};
 
-    my $default_record_type = $zone_record->{type};
+    my $default_record_type = $zone_record->{type} || $q->param('type');
     $default_record_type = 'PTR' if $zone->{zone} =~ /(in-addr|ip6)\.arpa/;
 
     my $rr_type_popup = _build_rr_type( $nt_obj, $q, $zone, $zone_record, $default_record_type, $modifyperm );


### PR DESCRIPTION
$default_record_type was not being set after a form submission error, resulting in selectedRRType() being called with an empty value, and thus not presenting the correct RR form fields.

fixes #104 