### PR TITLE
Make PowerDNS, NSD, Bind, and Knot exporters use the remote_login setting

### DIFF
--- a/server/lib/NicToolServer/Export/BIND.pm
+++ b/server/lib/NicToolServer/Export/BIND.pm
@@ -202,6 +202,7 @@ sub write_makefile {
 
     my $address = $self->{nte}{ns_ref}{address} || '127.0.0.1';
     my $datadir = $self->{nte}{ns_ref}{datadir} || getcwd . '/data-all';
+    my $remote_login = $self->{nte}{ns_ref}{remote_login} || 'bind';
     $datadir =~ s/\/$//;  # strip off any trailing /
     open my $M, '>', "$exportdir/Makefile" or do {
         warn "unable to open ./Makefile: $!\n";
@@ -222,11 +223,11 @@ compile: $exportdir/named.conf.nictool
 \ttest 1
 
 remote: $exportdir/named.conf.nictool
-\t#rsync -az --delete $exportdir/ bind\@$address:$datadir/
+\t#rsync -az --delete $exportdir/ $remote_login\@$address:$datadir/
 \ttest 1
 
 restart: $exportdir/named.conf.nictool
-\t#ssh bind\@$address rndc reload
+\t#ssh $remote_login\@$address rndc reload
 \ttest 1
 MAKE
 ;

--- a/server/lib/NicToolServer/Export/Knot.pm
+++ b/server/lib/NicToolServer/Export/Knot.pm
@@ -97,6 +97,7 @@ sub write_makefile {
     my $address = $self->{nte}{ns_ref}{address} || '127.0.0.1';
     my $datadir = $self->{nte}{ns_ref}{datadir} || getcwd . '/data-all';
     $datadir =~ s/\/$//;  # strip off any trailing /
+    my $remote_login = $self->{nte}{ns_ref}{remote_login} || 'knot';
     open my $M, '>', "$exportdir/Makefile" or do {
         warn "unable to open ./Makefile: $!\n";
         return;
@@ -116,10 +117,10 @@ compile: $exportdir/knot.conf.nictool
 \ttest 1
 
 remote: $exportdir/knot.conf.nictool
-\trsync -az --delete $exportdir/ knot\@$address:$datadir/
+\trsync -az --delete $exportdir/ $remote_login\@$address:$datadir/
 
 restart: $exportdir/knot.conf.nictool
-\tssh knot\@$address knotc reload
+\tssh $remote_login\@$address knotc reload
 MAKE
 ;
     close $M;

--- a/server/lib/NicToolServer/Export/NSD.pm
+++ b/server/lib/NicToolServer/Export/NSD.pm
@@ -41,6 +41,7 @@ sub write_makefile {
 
     my $address = $self->{nte}{ns_ref}{address} || '127.0.0.1';
     my $datadir = $self->{nte}{ns_ref}{datadir} || getcwd . '/data-all';
+    my $remote_login = $self->{nte}{ns_ref}{remote_login} || 'nsd';
     $datadir =~ s/\/$//;  # strip off any trailing /
     open my $M, '>', "$exportdir/Makefile" or do {
         warn "unable to open ./Makefile: $!\n";
@@ -63,16 +64,16 @@ compile: $exportdir/nsd.nictool.conf
 \tnsd-control rebuild
 
 remote: /var/db/nsd/nsd.db
-\trsync -az --delete /var/db/nsd/nsd.db nsd\@$address:/var/db/nsd/
+\trsync -az --delete /var/db/nsd/nsd.db $remote_login\@$address:/var/db/nsd/
 
 restart: nsd.db
-\tssh nsd\@$address nsd-control reload
+\tssh $remote_login\@$address nsd-control reload
 
 # NSD v3
 #compile: $exportdir/named.conf.nictool
 #\t nsdc rebuild
 #restart: nsd.db
-#\tssh nsd\@$address nsdc reload
+#\tssh $remote_login\@$address nsdc reload
 EO_MAKE
 ;
     close $M;

--- a/server/lib/NicToolServer/Export/PowerDNS.pm
+++ b/server/lib/NicToolServer/Export/PowerDNS.pm
@@ -32,6 +32,7 @@ sub write_makefile {
     my $address = $self->{nte}{ns_ref}{address} || '127.0.0.1';
     my $datadir = $self->{nte}{ns_ref}{datadir} || getcwd . '/data-all';
     $datadir =~ s/\/$//;  # strip off any trailing /
+    my $remote_login = $self->{nte}{ns_ref}{remote_login} || 'powerdns';
     open my $M, '>', "$exportdir/Makefile" or do {
         warn "unable to open ./Makefile: $!\n";
         return;
@@ -49,10 +50,10 @@ compile: $exportdir/named.conf.nictool
 \ttest 1
 
 remote: $exportdir/named.conf.nictool
-\trsync -az --delete $exportdir/ powerdns\@$address:$datadir/
+\trsync -az --delete $exportdir/ $remote_login\@$address:$datadir/
 
 restart: $exportdir/named.conf.nictool
-\tssh powerdns\@$address pdns_control cycle
+\tssh $remote_login\@$address pdns_control cycle
 MAKE
 ;
     close $M;


### PR DESCRIPTION
This pull request would fix issue #121 