### PR TITLE
Bind imports: restore functionality

### DIFF
--- a/client/lib/NicToolClient.pm
+++ b/client/lib/NicToolClient.pm
@@ -192,7 +192,7 @@ sub parse_template {
         print;
     }
 
-    close(FILE);
+    close $FILE;
 }
 
 sub fill_template_vars {

--- a/server/t/26_import_bind.t
+++ b/server/t/26_import_bind.t
@@ -1,0 +1,32 @@
+# NicTool v2.33 Copyright 2015 The Network People, Inc.
+#
+# NicTool is free software; you can redistribute it and/or modify it under
+# the terms of the Affero General Public License as published by Affero,
+# Inc.; either version 1 of the License, or any later version.
+#
+# NicTool is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the Affero GPL for details.
+#
+# You should have received a copy of the Affero General Public License
+# along with this program; if not, write to Affero Inc., 521 Third St,
+# Suite 225, San Francisco, CA 94107, USA
+
+use strict;
+use warnings;
+
+use lib '.';
+use lib 't';
+use lib 'lib';
+use Data::Dumper;
+use NicToolTest;
+use Test::More;
+use_ok('NicToolServer::Import::BIND');
+$Data::Dumper::Sortkeys=1;
+
+my $bind = NicToolServer::Import::BIND->new();
+ok($bind, 'new');
+
+$bind->import_zone('cybercity.dz', 't/fixtures/cybercity.dk');
+
+done_testing();

--- a/server/t/26_import_bind.t
+++ b/server/t/26_import_bind.t
@@ -27,6 +27,6 @@ $Data::Dumper::Sortkeys=1;
 my $bind = NicToolServer::Import::BIND->new();
 ok($bind, 'new');
 
-$bind->import_zone('cybercity.dz', 't/fixtures/cybercity.dk');
+$bind->import_records('t/fixtures/named.conf');
 
 done_testing();

--- a/server/t/fixtures/1.0.10.in-addr.arpa
+++ b/server/t/fixtures/1.0.10.in-addr.arpa
@@ -1,0 +1,13 @@
+
+$ORIGIN 1.0.10.in-addr.arpa.
+$TTL 86400
+1.0.10.in-addr.arpa. IN SOA ns1.cadillac.net. hostmaster.simerson.net. ( 2015122405 16384 2048 1048576 2560 )
+
+1.0.10.in-addr.arpa. 14400 IN NS ns1.cadillac.net.
+1.0.10.in-addr.arpa.	14400	IN	NS	ns2.cadillac.net.
+1.0.10.in-addr.arpa.	14400	IN	NS	ns3.cadillac.net.
+1	3600	IN  PTR	gw.simerson.net.
+202	3600	IN  PTR	treekiller.simerson.net.
+252	3600	IN  PTR	storage.simerson.net.
+203	3600	IN  PTR	color.simerson.net.
+65	3600	IN  PTR	nictool.

--- a/server/t/fixtures/138.80.85.in-addr.arpa
+++ b/server/t/fixtures/138.80.85.in-addr.arpa
@@ -1,0 +1,26 @@
+
+$TTL 3600
+@ IN SOA ns1.cybercity.dk. zonec.cybercity.dk. (
+1441353524 ; Serial
+10800 ; Refresh
+3600 ; Retry
+604800 ; Expire
+3600) ; Minimum
+
+@ NS ns1.cybercity.dk.
+@ NS ns2.cybercity.dk.
+@ NS ns3.cybercity.dk.
+@ NS ns4.cybercity.dk.
+
+0 PTR 0x55508a00.adsl.cybercity.dk.
+1 PTR 0x55508a01.adsl.cybercity.dk.
+2 PTR 0x55508a02.adsl.cybercity.dk.
+3 PTR 0x55508a03.adsl.cybercity.dk.
+4 PTR 0x55508a04.adsl.cybercity.dk.
+5 PTR 0x55508a05.adsl.cybercity.dk.
+6 PTR 0x55508a06.adsl.cybercity.dk.
+7 PTR 0x55508a07.adsl.cybercity.dk.
+8 PTR 0x55508a08.adsl.cybercity.dk.
+9 PTR 0x55508a09.adsl.cybercity.dk.
+10 PTR 0x55508a0a.adsl.cybercity.dk.
+11 PTR 0x55508a0b.adsl.cybercity.dk.

--- a/server/t/fixtures/example.com
+++ b/server/t/fixtures/example.com
@@ -1,0 +1,17 @@
+$ORIGIN example.com.     ; designates the start of this zone file in the namespace
+$TTL 1h                  ; default expiration time of all resource records without their own TTL value
+example.com.  IN  SOA   ns.example.com. username.example.com. ( 2007120710 1d 2h 4w 1h )
+example.com.  IN  NS    ns                    ; ns.example.com is a nameserver for example.com
+example.com.  IN  NS    ns.somewhere.example. ; ns.somewhere.example is a backup nameserver for example.com
+example.com.  IN  MX    10 mail.example.com.  ; mail.example.com is the mailserver for example.com
+@             IN  MX    20 mail2.example.com. ; equivalent to above line, "@" represents zone origin
+@             IN  MX    50 mail3              ; equivalent to above line, but using a relative host name
+example.com.  IN  A     192.0.2.1             ; IPv4 address for example.com
+              IN  AAAA  2001:db8:10::1        ; IPv6 address for example.com
+ns            IN  A     192.0.2.2             ; IPv4 address for ns.example.com
+              IN  AAAA  2001:db8:10::2        ; IPv6 address for ns.example.com
+www           IN  CNAME example.com.          ; www.example.com is an alias for example.com
+wwwtest       IN  CNAME www                   ; wwwtest.example.com is another alias for www.example.com
+mail          IN  A     192.0.2.3             ; IPv4 address for mail.example.com
+mail2         IN  A     192.0.2.4             ; IPv4 address for mail2.example.com
+mail3         IN  A     192.0.2.5             ; IPv4 address for mail3.example.com

--- a/server/t/fixtures/named.conf
+++ b/server/t/fixtures/named.conf
@@ -1,0 +1,4 @@
+
+zone "example.com"  { type master; file "t/fixtures/example.com"; };
+zone "1.0.10.in-addr.arpa"  { type master; file "t/fixtures/1.0.10.in-addr.arpa"; };
+zone "138.80.85.in-addr.arpa" { type master; file "t/fixtures/138.80.85.in-addr.arpa"; };


### PR DESCRIPTION
needs more and better testing.

Replaces the aged and problematic Net::DNS::Zone::Parser with Net::DNS::ZoneFile.

Intended to fix #79 and fix #73 