### PR TITLE
Export/BIND: add missing SOA values with defaults

### DIFF
--- a/client/lib/nictoolclient.conf.dist
+++ b/client/lib/nictoolclient.conf.dist
@@ -25,7 +25,7 @@ BEGIN {
 
     #Interface options
     $NicToolClient::app_title   = 'NicTool';
-    
+
     $NicToolClient::image_dir   = 'images';
 
     $NicToolClient::generic_error_message = qq(If you continue to get this error, please contact the system administrator, or your corporate contact.);
@@ -37,10 +37,10 @@ BEGIN {
     $NicToolClient::edit_after_new_zone = 1;
 
     #is the "include subgroups" checkbox automatically checked?
-    $NicToolClient::include_subgroups_checked = 1; 
+    $NicToolClient::include_subgroups_checked = 1;
 
     #is the "exact match" checkbox automatically checked?
-    $NicToolClient::exact_match_checked = 0; 
+    $NicToolClient::exact_match_checked = 0;
 
     $NicToolClient::template_dir                = "$NicToolClient::app_dir/templates";
     $NicToolClient::login_template              = "$NicToolClient::template_dir/login.html";

--- a/server/lib/NicToolServer/Export/BIND.pm
+++ b/server/lib/NicToolServer/Export/BIND.pm
@@ -299,6 +299,13 @@ sub zr_soa {
         $z->{mailaddr} .= '.';     # append trailing dot
     };
 
+    # reasonable defaults for unspecified values
+    $z->{ttl}     ||= 86400;
+    $z->{refresh} ||= 16384;
+    $z->{retry}   ||= 900;
+    $z->{expire}  ||= 1048576;
+    $z->{minimum} ||= 2560;
+
     # name        ttl class rr    name-server email-addr  (sn ref ret ex min)
     return "
 \$TTL    $z->{ttl};

--- a/server/lib/NicToolServer/Export/Knot.pm
+++ b/server/lib/NicToolServer/Export/Knot.pm
@@ -46,11 +46,11 @@ sub update_knot_include {
 sub update_knot_include_incremental {
     my ($self, $dir) = @_;
 
-# check that the zone(s) modified since our last export are in the
-# include file, else append it.
-#
-# there's likely to be more lines in the include file than zones to append
-# build a lookup table of changed zones and pass through the file once
+    # check that the zone(s) modified since our last export are in the
+    # include file, else append it.
+    #
+    # there's likely to be more lines in the include file than zones to append
+    # build a lookup table of changed zones and pass through the file once
     my $to_add = $self->get_changed_zones( $dir );
     my $file   = "$dir/knot.conf.nictool";
 
@@ -64,7 +64,7 @@ sub update_knot_include_incremental {
             return;
         };
 
-# simerson.net { file "/var/db/knot/simerson.net"; }
+    # simerson.net { file "/var/db/knot/simerson.net"; }
     while ( my $line = <$in> ) {
         my ($zone) = split /\s/, $line;
         if ( $to_add->{$zone} ) {

--- a/server/lib/nictoolserver.conf.dist
+++ b/server/lib/nictoolserver.conf.dist
@@ -37,7 +37,7 @@ BEGIN {
     # $NicToolServer::ldap_basedn   = 'ou=Nictool users,dc=example,dc=com';  # Search base
     # $NicToolServer::ldap_user_mapping = 'uid';                             # Defaults to 'uid'
 
-    # If ldap_filter is set, NicTool will perform a subtree search (scope: sub) for user under ldap_basedn, 
+    # If ldap_filter is set, NicTool will perform a subtree search (scope: sub) for user under ldap_basedn,
     # otherwise it will guesstimate the dn at basedn level (ala scope: one)
     # $NicToolServer::ldap_filter = '(&(objectClass=*)(uid=*))';
 
@@ -49,11 +49,3 @@ BEGIN {
 }
 
 1;
-
-__END__
-
-=head1 SYNOPSIS
-
-    
-=cut
-


### PR DESCRIPTION
Changes proposed in this pull request:
- when SOA values are missing during export, use defaults.
