### PR TITLE
Add support for CAA resource record type

### DIFF
--- a/client/htdocs/nt-script.js
+++ b/client/htdocs/nt-script.js
@@ -375,7 +375,7 @@ function setFormRRTypeURI() {
   $('input#priority').attr('placeholder','1');
 }
 
-function setFormTypeCAA() {
+function setFormRRTypeCAA() {
     setRfcHelp(['6844']);
 
     // For the Issuer Critical field we use 'weight':

--- a/client/htdocs/nt-script.js
+++ b/client/htdocs/nt-script.js
@@ -398,7 +398,7 @@ function setFormRRTypeCAA() {
     addValuesToSelect(properties, 'other');
 
     // And the Address field is the property value:
-    $('input#address_label').text('Property value');
+    $('td#address_label').text('Property value');
 }
 
 function setFormRRTypeHINFO() {

--- a/client/htdocs/nt-script.js
+++ b/client/htdocs/nt-script.js
@@ -61,6 +61,7 @@ function selectedRRType(rrType) {
       case 'RRSIG':      setFormRRTypeRRSIG();      break;
       case 'HINFO':      setFormRRTypeHINFO();      break;
       case 'URI':        setFormRRTypeURI();        break;
+      case 'CAA':        setFormRRTypeCAA();        break;
     }
 }
 
@@ -372,6 +373,32 @@ function setFormRRTypeURI() {
 
   $('#priority_row').show();
   $('input#priority').attr('placeholder','1');
+}
+
+function setFormTypeCAA() {
+    setRfcHelp(['6844']);
+
+    // For the Issuer Critical field we use 'weight':
+    $('#weight_row').show();
+    $('td#weight_label').text('Issuer critical');
+    var crit_values = {
+	'0' : 'Not critical',
+	'128' : 'Critical',
+    };
+    addValuesToSelect(crit_values, 'weight');
+    
+    // For the Property Tag field we (ab)use 'priority':
+    $('#priority_row').show();
+    $('td#priority_label').text('Property tag');
+    var properties = {
+	'issue' : 'issue',
+	'issuewild' : 'issuewild',
+	'iodef' : 'iodef',
+    };
+    addValuesToSelect(properties, 'priority');
+
+    // And the Address field is the property value:
+    $('input#address_label').text('Property value');
 }
 
 function setFormRRTypeHINFO() {

--- a/client/htdocs/nt-script.js
+++ b/client/htdocs/nt-script.js
@@ -388,14 +388,14 @@ function setFormRRTypeCAA() {
     addValuesToSelect(crit_values, 'weight');
     
     // For the Property Tag field we (ab)use 'priority':
-    $('#priority_row').show();
-    $('td#priority_label').text('Property tag');
+    $('#other_row').show();
+    $('td#other_label').text('Property tag');
     var properties = {
 	'issue' : 'issue',
 	'issuewild' : 'issuewild',
 	'iodef' : 'iodef',
     };
-    addValuesToSelect(properties, 'priority');
+    addValuesToSelect(properties, 'other');
 
     // And the Address field is the property value:
     $('input#address_label').text('Property value');

--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -760,10 +760,10 @@ sub display_zone_records_columns {
 
     my @columns = qw/ name type address ttl /;
 
-    if ( grep { $_->{type} =~ /^(?:MX|SRV|URI|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
+    if ( grep { $_->{type} =~ /^(?:MX|SRV|URI|CAA|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
         push @columns, 'weight';
     };
-    if ( grep { $_->{type} =~ /^(?:SRV|URI|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
+    if ( grep { $_->{type} =~ /^(?:SRV|URI|CAA|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
         push @columns, 'priority';
     };
     if ( grep { $_->{type} =~ /^(?:SRV|DS|IPSECKEY|DNSKEY)$/ } @$zone_records ) {

--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -763,10 +763,10 @@ sub display_zone_records_columns {
     if ( grep { $_->{type} =~ /^(?:MX|SRV|URI|CAA|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
         push @columns, 'weight';
     };
-    if ( grep { $_->{type} =~ /^(?:SRV|URI|CAA|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
+    if ( grep { $_->{type} =~ /^(?:SRV|URI|DS|IPSECKEY|DNSKEY|SSHFP|NAPTR)$/ } @$zone_records ) {
         push @columns, 'priority';
     };
-    if ( grep { $_->{type} =~ /^(?:SRV|DS|IPSECKEY|DNSKEY)$/ } @$zone_records ) {
+    if ( grep { $_->{type} =~ /^(?:SRV|DS|CAA|IPSECKEY|DNSKEY)$/ } @$zone_records ) {
         push @columns, 'other';
     }
     push @columns, 'description';

--- a/server/lib/NicToolServer/Export/BIND.pm
+++ b/server/lib/NicToolServer/Export/BIND.pm
@@ -458,7 +458,7 @@ sub zr_caa {
     my ($self, $r) = @_;
 
     my $crit = $self->{nte}->is_ip_port( $r->{weight} );
-    my $tag  = $self->{nte}->is_ip_port( $r->{priority} );
+    my $tag  = $self->{nte}->is_ip_port( $r->{other} );
     
     # Owner Name   TTL  CLASS   Type  Issue-Crit  Tag  Property
     return "$r->{name}	$r->{ttl}	IN  CAA $crit $tag \"$r->{address}\"\n";

--- a/server/lib/NicToolServer/Export/BIND.pm
+++ b/server/lib/NicToolServer/Export/BIND.pm
@@ -454,6 +454,17 @@ sub zr_uri {
     return "$r->{name}	$r->{ttl}	IN  URI	$priority	$weight	\"$r->{address}\"\n";
 }
 
+sub zr_caa {
+    my ($self, $r) = @_;
+
+    my $crit = $self->{nte}->is_ip_port( $r->{weight} );
+    my $tag  = $self->{nte}->is_ip_port( $r->{priority} );
+    
+    # Owner Name   TTL  CLASS   Type  Issue-Crit  Tag  Property
+    return "$r->{name}	$r->{ttl}	IN  CAA $crit $tag \"$r->{address}\"\n";
+}
+
+
 1;
 
 __END__

--- a/server/lib/NicToolServer/Export/tinydns.pm
+++ b/server/lib/NicToolServer/Export/tinydns.pm
@@ -340,7 +340,7 @@ sub zr_caa {
     my $r = shift or die;
 
     # First flag byte
-    my $rdata = octal_escape( pack "n", $r{weight} );
+    my $rdata = octal_escape( pack "n", $r->{weight} );
     # Then property tag as a length-prefixed text string
     $rdata .= $self->characterCount( $r->{priority} ) .
 	$self->escape( $r->{priority} );

--- a/server/lib/NicToolServer/Export/tinydns.pm
+++ b/server/lib/NicToolServer/Export/tinydns.pm
@@ -340,7 +340,7 @@ sub zr_caa {
     my $r = shift or die;
 
     # First flag byte
-    my $rdata = octal_escape( pack "n", $r->{weight} );
+    my $rdata = octal_escape( pack "C", $r->{weight} );
     # Then property tag as a length-prefixed text string
     $rdata .= $self->characterCount( $r->{other} ) .
 	$self->escape( $r->{other} );

--- a/server/lib/NicToolServer/Export/tinydns.pm
+++ b/server/lib/NicToolServer/Export/tinydns.pm
@@ -342,8 +342,8 @@ sub zr_caa {
     # First flag byte
     my $rdata = octal_escape( pack "n", $r->{weight} );
     # Then property tag as a length-prefixed text string
-    $rdata .= $self->characterCount( $r->{priority} ) .
-	$self->escape( $r->{priority} );
+    $rdata .= $self->characterCount( $r->{other} ) .
+	$self->escape( $r->{other} );
     # Then the property value as the rest of the data length
     $rdata .= $self->escape( $r->{address} );
     

--- a/server/lib/NicToolServer/Export/tinydns.pm
+++ b/server/lib/NicToolServer/Export/tinydns.pm
@@ -335,6 +335,21 @@ sub zr_uri {
     return $self->zr_generic( 256, $r, $rdata );
 }
 
+sub zr_caa {
+    my $self = shift;
+    my $r = shift or die;
+
+    # First flag byte
+    my $rdata = octal_escape( pack "n", $r{weight} );
+    # Then property tag as a length-prefixed text string
+    $rdata .= $self->characterCount( $r->{priority} ) .
+	$self->escape( $r->{priority} );
+    # Then the property value as the rest of the data length
+    $rdata .= $self->escape( $r->{address} );
+    
+    return $self->zr_generic( 257, $r, $rdata );
+}
+
 sub zr_srv {
     my $self = shift;
     my $r = shift or die;

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -81,6 +81,7 @@ sub new_or_edit_basic_verify {
     $self->_valid_srv  ( @args ) if $data->{type} eq 'SRV';
     $self->_valid_uri  ( @args ) if $data->{type} eq 'URI';
     $self->_valid_mx   ( @args ) if $data->{type} eq 'MX';
+    $self->_valid_caa  ( @args ) if $data->{type} eq 'CAA';
 
     $self->_name_collision($data, $z);
     $self->_valid_ttl( @args );
@@ -556,6 +557,47 @@ sub _valid_uri {
         $self->error( $check,
             "$values_to_check{$check} must be a 16bit integer, see RFC 7553"
         );
+    }
+}
+
+sub _valid_caa {
+    my ( $self, $data, $zone_text ) = @_;
+
+    my $crit = $data->{weight};
+    my $tag = $data->{priority};
+    my $value = $data->{address};
+
+    if ($crit != 0 && $crit != 128) {
+	$self->error('weight',
+		     "Critical flag must be either 0 or 128, see RFC 6844");
+    }
+
+    my %tags = (
+	'issue' => 1,
+	'issuewild' => 1,
+	'iodef' => 1,
+	);
+
+    if (!defined($tags{$tag})) {
+	my $valid_tags = join(" ", keys(%tags));
+	$self->error('priority',
+		     "Tag must be one of $valid_tags, see RFC 6844");
+    }
+
+    if ($tag eq "iodef") {
+	my @match_one = ("mailto:", "http:", "https:");
+	my $match = 0;
+	foreach (@match_one) {
+	    if ($value =~ /$_/i) {
+		$match = 1;
+	    }
+	}
+	if ($match == 0) {
+	    my $valid_uri_methods = join(", ", @match_one);
+	    $self->error('address',
+			 "Tag value for iodef must start with " .
+			 "one of $valid_uri_methods, see RFC 6844");
+	}
     }
 }
 

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -585,15 +585,10 @@ sub _valid_caa {
     }
 
     if ($tag eq "iodef") {
-	my @match_one = ("mailto:", "http:", "https:");
+	my @valid_iodef_schemes = ("mailto:", "http:", "https:");
 	my $match = 0;
-	foreach (@match_one) {
-	    if ($value =~ /$_/i) {
-		$match = 1;
-	    }
-	}
-	if ($match == 0) {
-	    my $valid_uri_methods = join(", ", @match_one);
+	if (grep { $value !~ /^$_/i } @valid_iodef_schemes) {
+	    my $valid_uri_methods = join(", ", @valid_iodef_schemes);
 	    $self->error('address',
 			 "Tag value for iodef must start with " .
 			 "one of $valid_uri_methods, see RFC 6844");

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -99,7 +99,9 @@ sub _valid_ttl {
 
     my @same_type = grep { $_->{type} eq $data->{type} } @$collisions;
     if (scalar @same_type && grep { $_->{ttl} != $data->{ttl} } @same_type) {
-        $self->error('ttl', "RRs with identical Name and Type must have identical TTL: RFC 2181");
+	# RRs with identical Name and type must have identical TTL: RFC 2181
+	# Just make it so by applying TTL update to all records in RRset
+	map { $_->{ttl} = $data->{ttl} } @same_type;
     }
 }
 

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -564,7 +564,7 @@ sub _valid_caa {
     my ( $self, $data, $zone_text ) = @_;
 
     my $crit = $data->{weight};
-    my $tag = $data->{priority};
+    my $tag = $data->{other};
     my $value = $data->{address};
 
     if ($crit != 0 && $crit != 128) {

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -101,7 +101,11 @@ sub _valid_ttl {
     if (scalar @same_type && grep { $_->{ttl} != $data->{ttl} } @same_type) {
 	# RRs with identical Name and type must have identical TTL: RFC 2181
 	# Just make it so by applying TTL update to all records in RRset
-	map { $_->{ttl} = $data->{ttl} } @same_type;
+	map { 
+	    $_->{ttl} = $data->{ttl};
+	    # Push that update to the DB as well(!)
+	    $self->SUPER::edit_zone_record($_);
+	} @same_type;
     }
 }
 

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -586,8 +586,7 @@ sub _valid_caa {
 
     if ($tag eq "iodef") {
 	my @valid_iodef_schemes = ("mailto:", "http:", "https:");
-	my $match = 0;
-	if (grep { $value !~ /^$_/i } @valid_iodef_schemes) {
+	if (! grep { $value =~ /^$_/i } @valid_iodef_schemes) {
 	    my $valid_uri_methods = join(", ", @valid_iodef_schemes);
 	    $self->error('address',
 			 "Tag value for iodef must start with " .

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -580,7 +580,7 @@ sub _valid_caa {
 
     if (!defined($tags{$tag})) {
 	my $valid_tags = join(" ", keys(%tags));
-	$self->error('priority',
+	$self->error('other',
 		     "Tag must be one of $valid_tags, see RFC 6844");
     }
 

--- a/server/sql/06_resource_records.sql
+++ b/server/sql/06_resource_records.sql
@@ -39,4 +39,5 @@ VALUES
     (99,'SPF','Sender Policy Framework',0,1,0),
     (250,'TSIG','Transaction Signature',0,0,0),
     (252,'AXFR',NULL,0,0,0),
-    (256,'URI','URI',0,1,0);
+    (256,'URI','URI',0,1,0),
+    (257,'CAA','Certification Authority Authorization',0,1,0);

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -439,7 +439,7 @@ sub doit {
 		ttl => 86400);
 	    my $zrid = $id->get('nt_zone_record_id');
 	    my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	    $id[$i] = $id;
+	    $id[$i] = $zrid;
 	    $zr[$i++] = $zr;
 	}
 
@@ -448,8 +448,8 @@ sub doit {
 	is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
 	# Cleanup after us...
 	foreach (@id) {
-	    $res = $user->delete_zone_record(
-		nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	    $res = $user->delete_zone_record( nt_zone_record_id => $_ );
+	    noerrok($res) or die "Could not delete test record $_";
 	}
     }
 

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,7 +428,7 @@ sub doit {
     }
 
     # TTL update of RRset
-    my(@zr);
+    my(@zr, @id);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
 	my $id = $zone1->new_zone_record(
@@ -438,6 +438,7 @@ sub doit {
 	    ttl => 86400);
 	my $zrid = $id->get('nt_zone_record_id');
 	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	$id[$i] = $id;
 	$zr[$i++] = $zr;
     }
 
@@ -445,7 +446,7 @@ sub doit {
     # Test that the update has been propagated to the whole RRset
     is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
     # Cleanup after us...
-    foreach (@zr) {
+    foreach (@ids) {
 	$res = $user->delete_zone_record(
 	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
     }

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -460,6 +460,7 @@ sub doit {
 	    address => 'some random string',
 	    priority => 'iodef',
 	    weight  => '0',
+	    ttl     => '3600',
 	    );
 	noerrok( $res, 300, 'Tag value for iodef' );
 	ok( $res->get('error_msg') =~ qr/Tag value for iodef/ );
@@ -478,6 +479,7 @@ sub doit {
 	    address => 'cert.example.com',
 	    priority => 'invalid-tag',
 	    weight  => '0',
+	    ttl     => '3600',
 	    );
 	noerrok( $res, 300, 'Tag must be one of' );
 	ok( $res->get('error_msg') =~ qr/Tag must be one of/ );
@@ -509,9 +511,9 @@ sub doit {
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ~all', type => 'SPF' },
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ?all', type => 'SPF' },
         { name => 'www', address => '2607:f729:0000:0000:0000:0000:0000:0001', type => 'AAAA', },
-	{ name => 'test.com.', weight => '0', priority => "issue", address => "ca.example.com", type => 'CAA' },
-	{ name => 'test.com.', weight => '128', priority => "iodef", address => "mailto:security@test.com", type => 'CAA' },
-	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/" },
+	{ name => 'test.com.', weight => '0', priority => "issue", address => "ca.example.com", type => 'CAA', ttl=>3600 },
+	{ name => 'test.com.', weight => '128', priority => "iodef", address => "mailto:security@test.com", type => 'CAA', ttl=>3600 },
+	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/", ttl=>3600 },
     );
 
     # new record success tests

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -429,7 +429,7 @@ sub doit {
 
     # TTL update of RRset
     
-    my(@zrs);
+    my(@zr);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
 	my $id = $zone1->new_zone_record(
@@ -439,7 +439,7 @@ sub doit {
 	    ttl => 86400);
 	my $zrid = $id->get('nt_zone_record_id');
 	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	$zrs[$i++] = $zr;
+	$zr[$i++] = $zr;
     }
 
     $res = $zr[0]->edit_zone_record( ttl => 6000 );

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -427,6 +427,26 @@ sub doit {
         }
     }
 
+    # TTL update of RRset
+    
+    my(@zrs);
+    my($i) = 0;
+    foreach ('1.2.3.4', '2.3.4.5') {
+	my $id = $zone1->new_zone_record(
+	    name => "rrsetname",
+	    address => $_,
+	    type => 'A',
+	    ttl => 86400);
+	my $zrid = $id->get('nt_zone_record_id');
+	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	$zrs[$i++] = $zr;
+    }
+
+    $res = $zr[0]->edit_zone_record( ttl => 6000 );
+    # Test that the update has been propagated to the whole RRset
+    is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+
+
     ####################
     # success tests    #
     ####################

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,27 +428,29 @@ sub doit {
     }
 
     # TTL update of RRset
-    my(@zr, @id);
-    my($i) = 0;
-    foreach ('1.2.3.4', '2.3.4.5') {
-	my $id = $zone1->new_zone_record(
-	    name => "rrsetname",
-	    address => $_,
-	    type => 'A',
-	    ttl => 86400);
-	my $zrid = $id->get('nt_zone_record_id');
-	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	$id[$i] = $id;
-	$zr[$i++] = $zr;
-    }
+    {
+        my(@zr, @id);
+	my($i) = 0;
+	foreach ('1.2.3.4', '2.3.4.5') {
+	    my $id = $zone1->new_zone_record(
+		name => "rrsetname",
+		address => $_,
+		type => 'A',
+		ttl => 86400);
+	    my $zrid = $id->get('nt_zone_record_id');
+	    my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	    $id[$i] = $id;
+	    $zr[$i++] = $zr;
+	}
 
-    $res = $zr[0]->edit_zone_record( ttl => 6000 );
-    # Test that the update has been propagated to the whole RRset
-    is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
-    # Cleanup after us...
-    foreach (@ids) {
-	$res = $user->delete_zone_record(
-	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	$res = $zr[0]->edit_zone_record( ttl => 6000 );
+	# Test that the update has been propagated to the whole RRset
+	is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+	# Cleanup after us...
+	foreach (@id) {
+	    $res = $user->delete_zone_record(
+		nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	}
     }
 
 

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -453,6 +453,41 @@ sub doit {
 	}
     }
 
+    # CAA with invalid URI for iodef
+    {
+	$res = $zone1->new_zone_record(
+	    name    => 'ca',
+	    address => 'some random string',
+	    priority => 'iodef',
+	    weight  => '0',
+	    );
+	noerrok( $res, 300, 'Tag value for iodef' );
+	ok( $res->get('error_msg') =~ qr/Tag value for iodef/ );
+	ok( $res->get('error_desc') =~ qr/Sanity error/ );
+	
+	if ( !$res->is_error ) {
+	    $res = $user->delete_zone_record(
+		nt_zone_record_id => $res->get('nt_zone_record_id') );
+	}
+    }
+
+    # CAA with invalid tag value
+    {
+	$res = $zone1->new_zone_record(
+	    name    => 'ca',
+	    address => 'cert.example.com',
+	    priority => 'invalid-tag',
+	    weight  => '0',
+	    );
+	noerrok( $res, 300, 'Tag must be one of' );
+	ok( $res->get('error_msg') =~ qr/Tag must be one of/ );
+	ok( $res->get('error_desc') =~ qr/Sanity error/ );
+
+	if ( !$res->is_error ) {
+	    $res = $user->delete_zone_record(
+		nt_zone_record_id => $res->get('nt_zone_record_id') );
+	}
+    }
 
     ####################
     # success tests    #
@@ -474,6 +509,9 @@ sub doit {
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ~all', type => 'SPF' },
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ?all', type => 'SPF' },
         { name => 'www', address => '2607:f729:0000:0000:0000:0000:0000:0001', type => 'AAAA', },
+	{ name => 'test.com.', weight => '0', priority => "issue", address => "ca.example.com", type => 'CAA' },
+	{ name => 'test.com.', weight => '128', priority => "iodef", address => "mailto:security@test.com", type => 'CAA' },
+	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/" },
     );
 
     # new record success tests

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -1050,9 +1050,10 @@ sub doit {
             name    => $_->{name},
             address => $_->{address},
             type    => $_->{type},
-            (($_->{type} eq 'MX' || $_->{type} eq 'SRV') ? (weight => 1) : ()),
-            ($_->{type} eq 'SRV' ? (priority => 1) : ()),
-            ($_->{type} eq 'SRV' ? (other => 1) : ()),
+            ($_->{ttl} ? (ttl => $_->{ttl}) : ()),
+            ($_->{weight} ? (weight => $_->{weight}) : ()),
+            ($_->{priority} ? (priority => $_->{priority}) : ()),
+            ($_->{other} ? (other => $_->{other}) : ()),
         );
 
         noerrok($res);

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,7 +428,6 @@ sub doit {
     }
 
     # TTL update of RRset
-    
     my(@zr);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
@@ -445,6 +444,11 @@ sub doit {
     $res = $zr[0]->edit_zone_record( ttl => 6000 );
     # Test that the update has been propagated to the whole RRset
     is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+    # Cleanup after us...
+    foreach (@zr) {
+	$res = $user->delete_zone_record(
+	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
+    }
 
 
     ####################

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -459,7 +459,7 @@ sub doit {
 	    name    => 'ca',
 	    type    => 'CAA',
 	    address => 'some random string',
-	    priority => 'iodef',
+	    other   => 'iodef',
 	    weight  => '0',
 	    ttl     => '3600',
 	    );
@@ -479,7 +479,7 @@ sub doit {
 	    name    => 'ca',
 	    type    => 'CAA',
 	    address => 'cert.example.com',
-	    priority => 'invalid-tag',
+	    other   => 'invalid-tag',
 	    weight  => '0',
 	    ttl     => '3600',
 	    );
@@ -513,9 +513,9 @@ sub doit {
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ~all', type => 'SPF' },
         { name => 'test.com.', address => 'v=spf1 mx a ip4:127.0.0.6 ?all', type => 'SPF' },
         { name => 'www', address => '2607:f729:0000:0000:0000:0000:0000:0001', type => 'AAAA', },
-	{ name => 'test.com.', weight => '0', priority => "issue", address => "ca.example.com", type => 'CAA', ttl=>3600 },
-	{ name => 'test.com.', weight => '128', priority => "iodef", address => "mailto:security@test.com", type => 'CAA', ttl=>3600 },
-	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/", type => 'CAA', ttl=>3600 },
+	{ name => 'test.com.', weight => '0', other => "issue", address => "ca.example.com", type => 'CAA', ttl=>3600 },
+	{ name => 'test.com.', weight => '128', other => "iodef", address => "mailto:security@test.com", type => 'CAA', ttl=>3600 },
+	{ name => 'test.com.', weight => '0', other => "iodef", address => "https://ca-report.test.com/", type => 'CAA', ttl=>3600 },
     );
 
     # new record success tests

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -457,6 +457,7 @@ sub doit {
     {
 	$res = $zone1->new_zone_record(
 	    name    => 'ca',
+	    type    => 'CAA',
 	    address => 'some random string',
 	    priority => 'iodef',
 	    weight  => '0',
@@ -476,6 +477,7 @@ sub doit {
     {
 	$res = $zone1->new_zone_record(
 	    name    => 'ca',
+	    type    => 'CAA',
 	    address => 'cert.example.com',
 	    priority => 'invalid-tag',
 	    weight  => '0',

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -515,7 +515,7 @@ sub doit {
         { name => 'www', address => '2607:f729:0000:0000:0000:0000:0000:0001', type => 'AAAA', },
 	{ name => 'test.com.', weight => '0', priority => "issue", address => "ca.example.com", type => 'CAA', ttl=>3600 },
 	{ name => 'test.com.', weight => '128', priority => "iodef", address => "mailto:security@test.com", type => 'CAA', ttl=>3600 },
-	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/", ttl=>3600 },
+	{ name => 'test.com.', weight => '0', priority => "iodef", address => "https://ca-report.test.com/", type => 'CAA', ttl=>3600 },
     );
 
     # new record success tests


### PR DESCRIPTION
Changes proposed in this pull request:
- Add support for the CAA resource record type

Tests will be added in a later commit, so hold off with merging of
this branch for now.

I'll note that the tinydns export of the CAA record is .. sketchy, and
needs further testing.