### PR TITLE
Remove potential security holes in NicTool, caused by calls to CGI->param() in list context.

### DIFF
--- a/client/htdocs/delegate_zones.cgi
+++ b/client/htdocs/delegate_zones.cgi
@@ -97,7 +97,7 @@ sub display_record {
 sub delegate_zones {
     my ( $nt_obj, $user, $q, $message, $edit ) = @_;
     my $modifyperm = $user->{'group_modify'} && $user->{'zone_delegate'} && $edit eq 'edit';
-    $q->param( 'obj_list', join( ',', $q->param('obj_list') ) );
+    $q->param( 'obj_list', join( ',', $q->multi_param('obj_list') ) );
     my $type  = $q->param('type');
     my $obj   = $type eq 'record' ? 'resource record' : 'zone';
     my $ucobj = $type eq 'record' ? 'Resource Record' : 'Zone';
@@ -107,11 +107,11 @@ sub delegate_zones {
     my $moreparams;
 
     if ($type) {
-        $moreparams = { type => $type, nt_zone_id => $q->param('nt_zone_id') };
+        $moreparams = { type => $type, nt_zone_id => scalar($q->param('nt_zone_id')) };
     }
     my $del;    #delegation object
     if ( $type ne 'record' ) {
-        my $rv = $nt_obj->get_zone_list( zone_list => $q->param('obj_list') );
+        my $rv = $nt_obj->get_zone_list( zone_list => scalar($q->param('obj_list')) );
 
         return $nt_obj->display_nice_error( $rv, "Get Zone Details" )
             if $rv->{'error_code'} != 200;
@@ -130,8 +130,8 @@ sub delegate_zones {
 <div id="delegateZoneList" class="light_grey_bg">Zone: $dzone</div>];
     }
     elsif ( $type eq 'record' ) {
-        my $zr = $nt_obj->get_zone_record( nt_zone_record_id => $q->param('obj_list') );
-        my $zone = $nt_obj->get_zone( nt_zone_id => $q->param('nt_zone_id') );
+        my $zr = $nt_obj->get_zone_record( nt_zone_record_id => scalar($q->param('obj_list')) );
+        my $zone = $nt_obj->get_zone( nt_zone_id => scalar($q->param('nt_zone_id')) );
 
         return $nt_obj->display_nice_error( $zr, "Get Zone Record Details" )
             if $zr->{'error_code'} != 200;
@@ -150,11 +150,11 @@ sub delegate_zones {
         my $delegates;
         if ( $type ne 'record' ) {
             $delegates = $nt_obj->get_zone_delegates(
-                nt_zone_id => $q->param('obj_list') );
+                nt_zone_id => scalar($q->param('obj_list')) );
         }
         elsif ( $type eq 'record' ) {
             $delegates = $nt_obj->get_zone_record_delegates(
-                nt_zone_record_id => $q->param('obj_list') );
+                nt_zone_record_id => scalar($q->param('obj_list')) );
         }
         return $nt_obj->display_nice_error( $delegates,
             "Get Zone " . ucfirst($type) . " Delegates List" )
@@ -174,15 +174,15 @@ sub delegate_zones {
         "\n",
         $q->hidden(
         -name     => 'obj_list',
-        -value    => join( ',', $q->param('obj_list') ),
+        -value    => join( ',', $q->multi_param('obj_list') ),
         -override => 1
         ),
         "\n", $q->hidden( -name => $edit, -value => 1 ),
-        "\n", $q->hidden( -name => 'type', -value => $q->param('type') ),
+        "\n", $q->hidden( -name => 'type', -value => scalar($q->param('type')) ),
         "\n", $q->hidden( -name  => 'nt_zone_id',
-            -value => $edit eq 'record' ? $q->param('nt_zone_id') : $q->param('obj_list')
+            -value => $edit eq 'record' ? scalar($q->param('nt_zone_id')) : scalar($q->param('obj_list'))
             ),
-        "\n", $q->hidden( -name=>'nt_group_id', -value=>$q->param('nt_group_id')),
+        "\n", $q->hidden( -name=>'nt_group_id', -value=>scalar($q->param('nt_group_id'))),
         "\n";
 
         if ( ref $del ) {
@@ -309,8 +309,8 @@ sub do_save {
     };
 
     my %params = (
-        nt_group_id => $q->param('group_list'),
-        $plist      => $q->param('obj_list'),
+        nt_group_id => scalar($q->param('group_list')),
+        $plist      => scalar($q->param('obj_list')),
     );
 
     foreach ( qw/ perm_write perm_delete perm_delegate 
@@ -343,8 +343,8 @@ sub do_modify {
     };
 
     my %params = (
-        nt_group_id => $q->param('nt_group_id'),
-        $list_id    => $q->param('obj_list')
+        nt_group_id => scalar($q->param('nt_group_id')),
+        $list_id    => scalar($q->param('obj_list'))
     );
 
     foreach ( qw/ perm_write perm_delete perm_delegate  
@@ -367,8 +367,8 @@ sub do_remove {
     my ($nt_obj, $q, $user) = @_;
 
     my $rv = $nt_obj->delete_zone_delegation(
-                nt_group_id => $q->param('nt_group_id'),
-                nt_zone_id  => $q->param('nt_zone_id'),
+                nt_group_id => scalar($q->param('nt_group_id')),
+                nt_zone_id  => scalar($q->param('nt_zone_id')),
             );
 
     if ( $rv->{'error_code'} != 200 ) {

--- a/client/htdocs/group.cgi
+++ b/client/htdocs/group.cgi
@@ -60,7 +60,7 @@ sub display {
     $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 1
+        scalar($q->param('nt_group_id')), 1
     );
 
     if ( $q->param('edit') ) {
@@ -95,12 +95,12 @@ sub display {
     }
 
     if ( $q->param('delete') ) {
-        my $rv = $nt_obj->delete_group( nt_group_id => $q->param('delete') );
+        my $rv = $nt_obj->delete_group( nt_group_id => scalar($q->param('delete')) );
         $nt_obj->display_nice_error( $rv, "Delete Group" ) if $rv->{'error_code'} != 200;
         $nt_obj->refresh_nav();
     }
 
-    my $group = $nt_obj->get_group( nt_group_id  => $q->param('nt_group_id') );
+    my $group = $nt_obj->get_group( nt_group_id  => scalar($q->param('nt_group_id')) );
 
     display_group_list( $nt_obj, $q, $group, $user );
 
@@ -111,10 +111,10 @@ sub _display_new_group {
     my ( $nt_obj, $q, $fields ) = @_;
 
     my %params = (
-        nt_group_id => $q->param('nt_group_id'),
-        name        => $q->param('name')
+        nt_group_id => scalar($q->param('nt_group_id')),
+        name        => scalar($q->param('name'))
     );
-    my @ns = $q->param("usable_nameservers");
+    my @ns = $q->multi_param("usable_nameservers");
     $params{"usable_nameservers"} = join( ',', @ns );
     foreach (@$fields) {
         $params{$_} = $q->param($_) ? 1 : 0;
@@ -127,11 +127,11 @@ sub _display_edit_group {
     my ( $nt_obj, $q, $fields ) = @_;
 
     my %params = (
-        nt_group_id => $q->param('nt_group_id'),
-        name        => $q->param('name'),
+        nt_group_id => scalar($q->param('nt_group_id')),
+        name        => scalar($q->param('name')),
     );
 
-    my @ns = $q->param("usable_nameservers");
+    my @ns = $q->multi_param("usable_nameservers");
     $params{"usable_nameservers"} = join( ",", @ns );
     foreach (@$fields) {
         $params{$_} = $q->param($_) ? 1 : 0;
@@ -186,8 +186,8 @@ sub display_group_list {
     my $include_subgroups = $group->{'has_children'} ? 'sub-groups' : undef;
 
     my %params = (
-        nt_group_id    => $q->param('nt_group_id'),
-        start_group_id => $q->param('nt_group_id'),
+        nt_group_id    => scalar($q->param('nt_group_id')),
+        start_group_id => scalar($q->param('nt_group_id')),
     );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 10 );
@@ -294,7 +294,7 @@ sub _display_group_create_link {
 
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        $state .= "&amp;$_=" . $q->escape( $q->param($_) );
+        $state .= "&amp;$_=" . $q->escape( scalar($q->param($_)) );
     }
     print qq[<a href="group.cgi?$state&amp;new=1">New Sub-Group</a></span></div>];
 };
@@ -306,7 +306,7 @@ sub display_edit {
     my %param = ();
 
     if ( $edit eq 'edit' ) {
-        my $rv = $nt_obj->get_group( nt_group_id => $q->param('nt_group_id') );
+        my $rv = $nt_obj->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
 
         return $nt_obj->display_nice_error( $rv, "Get Group Details" )
             if $rv->{'error_code'} != 200;
@@ -318,7 +318,7 @@ sub display_edit {
     }
     else {
         if ( $q->param('nt_group_id') eq $user->{'nt_group_id'} ) {
-            %param = ( nt_group_id => $q->param('nt_group_id') );
+            %param = ( nt_group_id => scalar($q->param('nt_group_id')) );
         };
     }
 

--- a/client/htdocs/group_log.cgi
+++ b/client/htdocs/group_log.cgi
@@ -52,7 +52,7 @@ sub display {
     );
 
     my $level = $nt_obj->display_group_tree(
-        $user, $user->{'nt_group_id'}, $q->param('nt_group_id'), 0
+        $user, $user->{'nt_group_id'}, scalar($q->param('nt_group_id')), 0
     );
 
     print qq[ 
@@ -92,7 +92,7 @@ sub display_log {
         description => 'Description',
     );
 
-    my $group = $nt_obj->get_group( nt_group_id  => $q->param('nt_group_id') );
+    my $group = $nt_obj->get_group( nt_group_id  => scalar($q->param('nt_group_id')) );
     my $include_subgroups = $group->{'has_children'} ? 'sub-groups' : undef;
 
     $nt_obj->display_sort_options( $q, \@columns, \%labels, 'group_log.cgi',
@@ -102,7 +102,7 @@ sub display_log {
         'group_log.cgi', ['nt_group_id'], $include_subgroups )
             if $q->param('edit_search');
 
-    my %params = ( nt_group_id => $q->param('nt_group_id') );
+    my %params = ( nt_group_id => scalar($q->param('nt_group_id')) );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 50 );
 
@@ -119,7 +119,7 @@ sub display_log {
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        push @state_fields, "$_=" . $q->escape( $q->param($_) );
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) );
     }
     my $state_string = @state_fields ? join('&amp;', @state_fields) : 'not_empty=1';
 

--- a/client/htdocs/group_nameservers.cgi
+++ b/client/htdocs/group_nameservers.cgi
@@ -50,15 +50,15 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
-    display_list_options( $user, $q->param('nt_group_id'), $level, 1 );
+    display_list_options( $user, scalar($q->param('nt_group_id')), $level, 1 );
 
     do_new( $nt_obj, $q, $user );
     do_edit( $nt_obj, $q, $user );
     do_delete( $nt_obj, $q );
 
-    my $group = $nt_obj->get_group( nt_group_id => $q->param('nt_group_id') );
+    my $group = $nt_obj->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
 
     display_list( $nt_obj, $q, $group, $user );
 
@@ -94,8 +94,8 @@ sub do_delete {
     return if ! $q->param('delete');
 
     my $error = $nt_obj->delete_nameserver(
-        nt_group_id      => $q->param('nt_group_id'),
-        nt_nameserver_id => $q->param('nt_nameserver_id')
+        nt_group_id      => scalar($q->param('nt_group_id')),
+        nt_nameserver_id => scalar($q->param('nt_nameserver_id'))
     );
     if ( $error->{'error_code'} != 200 ) {
         $nt_obj->display_nice_error( $error, "Delete Nameserver" );
@@ -150,7 +150,7 @@ sub display_list {
         unshift @columns, 'group_name';
     }
 
-    my %params = ( nt_group_id => $q->param('nt_group_id') );
+    my %params = ( nt_group_id => scalar($q->param('nt_group_id')) );
 
     my $rv = $nt_obj->get_group_nameservers(%params);
 
@@ -172,12 +172,12 @@ sub display_list {
     my $state;
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        $state .= "&amp;$_=" . $q->escape( $q->param($_) );
+        $state .= "&amp;$_=" . $q->escape( scalar($q->param($_)) );
     }
 
     display_list_actions( $q, $user, $user_group, $state, $list );
 
-    my %params = ( nt_group_id => $q->param('nt_group_id') );
+    my %params = ( nt_group_id => scalar($q->param('nt_group_id')) );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 100 );
     if ( ! %sort_fields ) {
@@ -430,8 +430,8 @@ sub display_edit_nameserver {
     if ( $q->param('nt_nameserver_id') && !$q->param('Save') ) {
         # get current settings
         $nameserver = $nt_obj->get_nameserver(
-            nt_group_id      => $q->param('nt_group_id'),
-            nt_nameserver_id => $q->param('nt_nameserver_id')
+            nt_group_id      => scalar($q->param('nt_group_id')),
+            nt_nameserver_id => scalar($q->param('nt_nameserver_id'))
         );
         if ( $nameserver->{'error_code'} != 200 ) {
             $message = $nameserver;

--- a/client/htdocs/group_users.cgi
+++ b/client/htdocs/group_users.cgi
@@ -50,11 +50,11 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
 
-    $nt_obj->display_user_list_options( $user, $q->param('nt_group_id'), $level, 1 );
-    my $group = $nt_obj->get_group( nt_group_id => $q->param('nt_group_id') );
+    $nt_obj->display_user_list_options( $user, scalar($q->param('nt_group_id')), $level, 1 );
+    my $group = $nt_obj->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
 
     my @fields = qw/ user_create user_delete user_write group_create group_delete group_write zone_create zone_delegate zone_delete zone_write zonerecord_create zonerecord_delegate zonerecord_delete zonerecord_write nameserver_create nameserver_delete nameserver_write self_write /;
 
@@ -78,7 +78,7 @@ sub display {
     }
 
     if ( $q->param('delete') ) {
-        my $error = $nt_obj->delete_users( user_list => $q->param('obj_list') );
+        my $error = $nt_obj->delete_users( user_list => scalar($q->param('obj_list')) );
         if ( $error->{'error_code'} != 200 ) {
             $nt_obj->display_nice_error( $error, "Delete Users" );
         }
@@ -196,7 +196,7 @@ sub display_list {
         unshift @columns, 'group_name';
     }
 
-    my %params = ( nt_group_id => $q->param('nt_group_id') );
+    my %params = ( nt_group_id => scalar($q->param('nt_group_id')) );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 100 );
     if ( ! %sort_fields ) {
@@ -223,7 +223,7 @@ sub display_list {
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        push @state_fields, "$_=" . $q->escape( $q->param($_) );
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) );
     }
     my $gid = $q->param('nt_group_id');
     my $state_string = "nt_group_id=$gid" . join('&amp;', @state_fields);

--- a/client/htdocs/group_zones.cgi
+++ b/client/htdocs/group_zones.cgi
@@ -52,12 +52,12 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
 
-    $nt_obj->display_zone_list_options( $user, $q->param('nt_group_id'), $level, 1 );
+    $nt_obj->display_zone_list_options( $user, scalar($q->param('nt_group_id')), $level, 1 );
 
-    my $group = $nt_obj->get_group( nt_group_id => $q->param('nt_group_id') );
+    my $group = $nt_obj->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
 
     if ( $q->param('new') ) {
         $nt_obj->display_nice_message(@$nicemessage) if $nicemessage;
@@ -79,7 +79,7 @@ sub _display_delete {
     return if ! $q->param('delete');
     return if ! $q->param('zone_list');
 
-    my @zl = $q->param('zone_list');
+    my @zl = $q->multi_param('zone_list');
     my $error = $nt_obj->delete_zones( zone_list => join( ',', @zl ) );
 
     if ( $error->{'error_code'} != 200 ) {
@@ -104,8 +104,8 @@ sub _display_delete_delegate {
     return if ! $q->param('nt_group_id');
 
     my $error = $nt_obj->delete_zone_delegation(
-        nt_zone_id  => $q->param('nt_zone_id'),
-        nt_group_id => $q->param('nt_group_id')
+        nt_zone_id  => scalar($q->param('nt_zone_id')),
+        nt_group_id => scalar($q->param('nt_group_id'))
     );
     if ( $error->{'error_code'} != 200 ) {
         $nt_obj->display_nice_error( $error, "Remove Zone Delegation" );
@@ -129,7 +129,7 @@ sub _display_edit {
 
         my %data;
         foreach (@fields) { $data{$_} = $q->param($_); }
-        $data{'nameservers'} = join( ',', $q->param('nameservers') );
+        $data{'nameservers'} = join( ',', $q->multi_param('nameservers') );
 
         my $error = $nt_obj->edit_zone(%data);
         if ( $error->{'error_code'} != 200 ) {
@@ -175,7 +175,7 @@ sub display_list {
     }
     unshift @columns, 'zone';
 
-    my %params = ( nt_group_id => $q->param('nt_group_id') );
+    my %params = ( nt_group_id => scalar($q->param('nt_group_id')) );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 100 );
     if ( ! %sort_fields ) {
@@ -202,7 +202,7 @@ sub display_list {
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        push @state_fields, "$_=" . $q->escape( $q->param($_) );
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) );
     }
     my $gid = $q->param('nt_group_id');
     my $state_string = join('&amp;', @state_fields, "nt_group_id=$gid");
@@ -527,7 +527,7 @@ sub _get_available_nameservers {
     my ($nt_obj, $q) = @_;
 
     my $ns_tree = $nt_obj->get_usable_nameservers(
-        nt_group_id => $q->param('nt_group_id')
+        nt_group_id => scalar($q->param('nt_group_id'))
     );
 
     if ( @{ $ns_tree->{'nameservers'} } == 0 ) {
@@ -596,7 +596,7 @@ sub add_zone {
                 refresh retry expire minimum mailaddr template ttl /;
     my %data;
     foreach (@fields) { $data{$_} = $q->param($_); }
-    $data{'nameservers'} = join( ',', $q->param('nameservers') );
+    $data{'nameservers'} = join( ',', $q->multi_param('nameservers') );
 
     my $error = $nt_obj->new_zone(%data);
     if ( $error->{'error_code'} != 200 ) {
@@ -606,12 +606,12 @@ sub add_zone {
     # do the template stuff here
     my $nt_zone_id   = $error->{'nt_zone_id'};
     my $zone_records = $nt_obj->zone_record_template(
-        {   zone       => $q->param('zone'),
+        {   zone       => scalar($q->param('zone')),
             nt_zone_id => $nt_zone_id,
-            template   => $q->param('template'),
-            newip      => $q->param('newip'),
-            mailip     => $q->param('mailip'),
-            debug      => $q->param('debug')
+            template   => scalar($q->param('template')),
+            newip      => scalar($q->param('newip')),
+            mailip     => scalar($q->param('mailip')),
+            debug      => scalar($q->param('debug'))
         }
     );
     add_zone_records( $nt_obj, $zone_records );
@@ -659,7 +659,7 @@ sub display_zone_actions {
 
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
-        push @state_fields, "$_=" . $q->escape( $q->param($_) ) if $q->param($_);
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) ) if $q->param($_);
     }
     my $gid = $q->param('nt_group_id');
     my $state_string = join('&amp;', @state_fields, "nt_group_id=$gid");

--- a/client/htdocs/group_zones_log.cgi
+++ b/client/htdocs/group_zones_log.cgi
@@ -55,10 +55,10 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
 
-    $nt_obj->display_zone_list_options( $user, $q->param('nt_group_id'), $level, 0 );
+    $nt_obj->display_zone_list_options( $user, scalar($q->param('nt_group_id')), $level, 0 );
 
     print qq[<table class="fat">
  <tr class=light_grey_bg>
@@ -98,7 +98,7 @@ sub display_log {
     my $cgi        = 'group_zones_log.cgi';
     my @req_fields = qw(nt_group_id);
 
-    my $group = $nt_obj->get_group( nt_group_id  => $q->param('nt_group_id') );
+    my $group = $nt_obj->get_group( nt_group_id  => scalar($q->param('nt_group_id')) );
 
     my $include_subgroups = $group->{'has_children'} ? 'sub-groups' : undef;
     push( @columns, 'group_name' ) if $include_subgroups;
@@ -110,7 +110,7 @@ sub display_log {
         \@req_fields, $include_subgroups )
         if $q->param('edit_search');
 
-    my %params = ( map { $_, $q->param($_) } @req_fields );
+    my %params = ( map { $_, scalar($q->param($_)) } @req_fields );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields,
         $NicToolClient::page_length );
@@ -126,7 +126,7 @@ sub display_log {
 
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
-        push( @state_fields, "$_=" . $q->escape( $q->param($_) ) )
+        push( @state_fields, "$_=" . $q->escape( scalar($q->param($_)) ) )
             if ( $q->param($_) );
     }
 

--- a/client/htdocs/group_zones_query_log.cgi
+++ b/client/htdocs/group_zones_query_log.cgi
@@ -50,9 +50,9 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
-    $nt_obj->display_zone_list_options( $user, $q->param('nt_group_id'), $level, 0 );
+    $nt_obj->display_zone_list_options( $user, scalar($q->param('nt_group_id')), $level, 0 );
 
     print qq[<table class="fat">
     <tr class=light_grey_bg><td><table class="no_pad fat">

--- a/client/htdocs/help.cgi
+++ b/client/htdocs/help.cgi
@@ -96,11 +96,11 @@ sub display {
 
     my $message;
     my $topics = help_text;
-    my $t      = $topics->{ $q->param('topic') };
+    my $t      = $topics->{ scalar($q->param('topic')) };
 
     if (   $q->param("topic")
         && $q->param('topic') ne 'all'
-        && !exists $topics->{ $q->param('topic') } )
+        && !exists $topics->{ scalar($q->param('topic')) } )
     {
         $message = {
             error_msg =>
@@ -109,7 +109,7 @@ sub display {
         };
     }
 
-    if ( $q->param("topic") && exists $topics->{ $q->param('topic') } ) {
+    if ( $q->param("topic") && exists $topics->{ scalar($q->param('topic')) } ) {
         if ( $t->{'template'} ) {
             $nt_obj->parse_template(
                 $NicToolClient::template_dir . "/help_start.html", %$t );

--- a/client/htdocs/index.cgi
+++ b/client/htdocs/index.cgi
@@ -40,7 +40,7 @@ sub main {
 
     my $cookie = $q->cookie('NicTool');
     if ( ! $cookie ) {
-        $nt_obj->display_login( $q->param('message') );
+        $nt_obj->display_login( scalar($q->param('message')) );
         return;
     }
 

--- a/client/htdocs/move_nameservers.cgi
+++ b/client/htdocs/move_nameservers.cgi
@@ -54,8 +54,8 @@ sub display {
     }
     elsif ( $q->param('Save') ) {
         my $rv = $nt_obj->move_nameservers(
-            nt_group_id     => $q->param('group_list'),
-            nameserver_list => $q->param('obj_list')
+            nt_group_id     => scalar($q->param('group_list')),
+            nameserver_list => scalar($q->param('obj_list'))
         );
         if ( $rv->{'error_code'} != 200 ) {
 
@@ -77,10 +77,10 @@ sub display {
 sub move {
     my ( $nt_obj, $user, $q, $message ) = @_;
 
-    $q->param( 'obj_list', join( ',', $q->param('obj_list') ) );
+    $q->param( 'obj_list', join( ',', $q->multi_param('obj_list') ) );
 
     my $rv = $nt_obj->get_nameserver_list(
-        nameserver_list => $q->param('obj_list') );
+        nameserver_list => scalar($q->param('obj_list')) );
 
     return $nt_obj->display_error($rv) if ( $rv->{'error_code'} != 200 );
 

--- a/client/htdocs/move_users.cgi
+++ b/client/htdocs/move_users.cgi
@@ -54,8 +54,8 @@ sub display {
     }
     elsif ( $q->param('Save') ) {
         my $rv = $nt_obj->move_users(
-            nt_group_id => $q->param('group_list'),
-            user_list   => $q->param('obj_list')
+            nt_group_id => scalar($q->param('group_list')),
+            user_list   => scalar($q->param('obj_list'))
         );
         if ( $rv->{'error_code'} != 200 ) {
 
@@ -77,11 +77,11 @@ sub display {
 sub move {
     my ( $nt_obj, $user, $q, $message ) = @_;
 
-    $q->param( 'obj_list', join( ',', $q->param('obj_list') ) );
+    $q->param( 'obj_list', join( ',', $q->multi_param('obj_list') ) );
 
     #warn "obj_list = " . $q->param('obj_list') . " ..\n";
 
-    my $rv = $nt_obj->get_user_list( user_list => $q->param('obj_list') );
+    my $rv = $nt_obj->get_user_list( user_list => scalar($q->param('obj_list')) );
 
     return $nt_obj->display_error($rv) if ( $rv->{'error_code'} != 200 );
 

--- a/client/htdocs/move_zones.cgi
+++ b/client/htdocs/move_zones.cgi
@@ -54,8 +54,8 @@ sub display {
     }
     elsif ( $q->param('Save') ) {
         my $rv = $nt_obj->move_zones(
-            nt_group_id => $q->param('group_list'),
-            zone_list   => $q->param('obj_list')
+            nt_group_id => scalar($q->param('group_list')),
+            zone_list   => scalar($q->param('obj_list'))
         );
         if ( $rv->{'error_code'} != 200 ) {
             move_zones( $nt_obj, $user, $q, $rv );
@@ -74,9 +74,9 @@ sub display {
 sub move_zones {
     my ( $nt_obj, $user, $q, $message ) = @_;
 
-    $q->param( 'obj_list', join( ',', $q->param('obj_list') ) );
+    $q->param( 'obj_list', join( ',', $q->multi_param('obj_list') ) );
 
-    my $rv = $nt_obj->get_zone_list( zone_list => $q->param('obj_list') );
+    my $rv = $nt_obj->get_zone_list( zone_list => scalar($q->param('obj_list')) );
 
     return $nt_obj->display_error($rv) if $rv->{'error_code'} != 200;
 

--- a/client/htdocs/nav.cgi
+++ b/client/htdocs/nav.cgi
@@ -41,7 +41,7 @@ sub display {
     $nt_obj->parse_template($NicToolClient::start_html_template);
 
     my $expanded = {
-        'expanded' => { map { $_, 1 } split( /,/, $q->param('expanded') ) } };
+        'expanded' => { map { $_, 1 } split( /,/, scalar($q->param('expanded')) ) } };
 
     my $group = $nt_obj->get_group( nt_group_id => $user->{'nt_group_id'} );
 

--- a/client/htdocs/user.cgi
+++ b/client/htdocs/user.cgi
@@ -51,7 +51,7 @@ sub display {
         userid    => $user->{'nt_user_id'}
     );
 
-    my $duser = $nt_obj->get_user( nt_user_id => $q->param('nt_user_id') );
+    my $duser = $nt_obj->get_user( nt_user_id => scalar($q->param('nt_user_id')) );
     if ( $duser->{'error_code'} ne 200 ) {
         print $nt_obj->display_error($duser);
     }
@@ -94,7 +94,7 @@ sub display {
 
         # refresh the user info displayed in form
         if ( $q->param('nt_user_id') ) {
-            $duser = $nt_obj->get_user( nt_user_id => $q->param('nt_user_id') );
+            $duser = $nt_obj->get_user( nt_user_id => scalar($q->param('nt_user_id')) );
         };
     };
 
@@ -103,9 +103,9 @@ sub display {
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
-    $nt_obj->display_user_list_options( $user, $q->param('nt_group_id'), $level, 0 );
+    $nt_obj->display_user_list_options( $user, scalar($q->param('nt_group_id')), $level, 0 );
 
     $level++;
 
@@ -187,7 +187,7 @@ sub display_properties {
 
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
-        push( @state_fields, "$_=" . $q->escape( $q->param($_) ) )
+        push( @state_fields, "$_=" . $q->escape( scalar($q->param($_)) ) )
             if ( $q->param($_) );
     }
 
@@ -264,7 +264,7 @@ sub display_global_log {
         \@req_fields )
         if $q->param('edit_search');
 
-    my %params = ( map { $_ => $q->param($_) } @req_fields );
+    my %params = ( map { $_ => scalar($q->param($_)) } @req_fields );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields,
         20 );
@@ -279,7 +279,7 @@ sub display_global_log {
 
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
-        push( @state_fields, "$_=" . $q->escape( $q->param($_) ) )
+        push( @state_fields, "$_=" . $q->escape( scalar($q->param($_)) ) )
             if ( $q->param($_) );
     }
 

--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -48,12 +48,12 @@ sub display {
         userid    => $user->{'nt_user_id'},
     );
 
-    my $zone = $nt_obj->get_zone( nt_zone_id => $q->param('nt_zone_id') );
+    my $zone = $nt_obj->get_zone( nt_zone_id => scalar($q->param('nt_zone_id')) );
 
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $zone->{'delegated_by_id'} ? '' : $q->param('nt_group_id'), 0
+        $zone->{'delegated_by_id'} ? '' : scalar($q->param('nt_group_id')), 0
     );
 
     if ( $zone->{'error_code'} ne 200 ) {
@@ -61,7 +61,7 @@ sub display {
         return;
     }
 
-    $nt_obj->display_zone_list_options( $user, $q->param('nt_group_id'), $level, 0 );
+    $nt_obj->display_zone_list_options( $user, scalar($q->param('nt_group_id')), $level, 0 );
     $nt_obj->display_zone_options( $user, $zone, $level + 1, 0 );    #1);
 
     $zone = display_zone( $nt_obj, $user, $q, $zone );
@@ -103,8 +103,8 @@ sub do_delete_delegation {
 
     if ( $q->param('type') ne 'record' && $q->param('nt_zone_id') ) {
         my $error = $nt_obj->delete_zone_delegation(
-            nt_zone_id  => $q->param('nt_zone_id'),
-            nt_group_id => $q->param('delegate_group_id')
+            nt_zone_id  => scalar($q->param('nt_zone_id')),
+            nt_group_id => scalar($q->param('delegate_group_id'))
         );
         if ( $error->{'error_code'} != 200 ) {
             $nt_obj->display_nice_error( $error, "Delete Zone Delegation" );
@@ -117,8 +117,8 @@ sub do_delete_delegation {
     }
     elsif ( $q->param('type') eq 'record' && $q->param('nt_zone_record_id') ) {
         my $error = $nt_obj->delete_zone_record_delegation(
-            nt_zone_record_id => $q->param('nt_zone_record_id'),
-            nt_group_id       => $q->param('delegate_group_id')
+            nt_zone_record_id => scalar($q->param('nt_zone_record_id')),
+            nt_group_id       => scalar($q->param('delegate_group_id'))
         );
         if ( $error->{'error_code'} != 200 ) {
             $nt_obj->display_nice_error( $error,
@@ -150,7 +150,7 @@ sub do_edit_zone {
         next if ! defined $q->param($_);
         $data{$_} = $q->param($_);
     };
-    $data{'nameservers'} = join( ',', $q->param('nameservers') );
+    $data{'nameservers'} = join( ',', $q->multi_param('nameservers') );
     if ( $q->param('undelete') ) {
         $data{'deleted'} = 0;
     };
@@ -161,8 +161,8 @@ sub do_edit_zone {
         return;
     };
     return $nt_obj->get_zone(
-        nt_group_id => $q->param('nt_group_id'),
-        nt_zone_id  => $q->param('nt_zone_id')
+        nt_group_id => scalar($q->param('nt_group_id')),
+        nt_zone_id  => scalar($q->param('nt_zone_id'))
     );
 };
 
@@ -179,8 +179,8 @@ sub do_new_zone {
 
     my @fields = qw/ nt_group_id zone nameservers description mailaddr
                     serial refresh retry expire ttl minimum/;
-    my %data = map { $_ => $q->param($_) } @fields;
-    $data{'nameservers'} = join( ',', $q->param('nameservers') );
+    my %data = map { $_ => scalar($q->param($_)) } @fields;
+    $data{'nameservers'} = join( ',', $q->multi_param('nameservers') );
 
     my $error = $nt_obj->new_zone(%data);
     if ( $error->{'error_code'} != 200 ) {
@@ -195,7 +195,7 @@ sub do_new_zone {
         return $nt_obj->redirect_from_log($q);
     }
     $zone = $nt_obj->get_zone(
-        nt_group_id => $q->param('nt_group_id'),
+        nt_group_id => scalar($q->param('nt_group_id')),
         nt_zone_id  => $zid,
     );
     if ( $zone->{'error_code'} != 200 ) {
@@ -367,7 +367,7 @@ sub display_zone_properties {
     my $state = 'nt_group_id=' . $q->param('nt_group_id');
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        $state .= "&amp;$_=" . $q->escape( $q->param($_) );
+        $state .= "&amp;$_=" . $q->escape( scalar($q->param($_)) );
     }
     $state .= "&amp;nt_zone_id=$zone->{'nt_zone_id'}&amp;edit_zone=1";
 
@@ -444,7 +444,7 @@ sub display_nameservers {
         my $state = 'nt_group_id=' . $q->param('nt_group_id');
         foreach ( @{ $nt_obj->paging_fields } ) {
             next if ! $q->param($_);
-            $state .= "&amp;$_=" . $q->escape( $q->param($_) );
+            $state .= "&amp;$_=" . $q->escape( scalar($q->param($_)) );
         }
         $state .= "&amp;nt_zone_id=$zone->{'nt_zone_id'}&amp;edit_zone=1";
         print qq[<li><a href="zone.cgi?$state">Edit</a></li>];
@@ -503,7 +503,7 @@ sub display_zone_records {
             [ 'nt_group_id', 'nt_zone_id' ] );
     };
 
-    my %params = ( nt_zone_id => $q->param('nt_zone_id') );
+    my %params = ( nt_zone_id => scalar($q->param('nt_zone_id')) );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields, 50 );
     if ( ! %sort_fields ) {
@@ -519,7 +519,7 @@ sub display_zone_records {
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
         next if ! $q->param($_);
-        push @state_fields, "$_=" . $q->escape( $q->param($_) );
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) );
     }
     my $state_string = join('&amp;', @state_fields);
 
@@ -670,7 +670,7 @@ sub display_zone_records_new {
     my @fields = qw/ nt_group_id nt_zone_id name type address
                      weight priority other ttl location description /;
 
-    my %data = map { $_ => $q->param($_) } @fields;
+    my %data = map { $_ => scalar($q->param($_)) } @fields;
 
     my $error = $nt_obj->new_zone_record(%data);
     if ( $error->{'error_code'} != 200 ) {
@@ -713,8 +713,8 @@ sub display_zone_records_delete {
     return if ! $q->param('delete_record');
 
     my $error = $nt_obj->delete_zone_record(
-        nt_group_id       => $q->param('nt_group_id'),
-        nt_zone_record_id => $q->param('nt_zone_record_id')
+        nt_group_id       => scalar($q->param('nt_group_id')),
+        nt_zone_record_id => scalar($q->param('nt_zone_record_id'))
     );
 
     if ( $error->{'error_code'} != 200 ) {
@@ -950,16 +950,16 @@ sub _display_edit_record_action {
     if ( $q->param('nt_zone_record_log_id') ) {
         $action = 'Recover';
         $zone_record = $nt_obj->get_zone_record_log_entry(
-            nt_zone_record_id     => $q->param('nt_zone_record_id'),
-            nt_zone_record_log_id => $q->param('nt_zone_record_log_id')
+            nt_zone_record_id     => scalar($q->param('nt_zone_record_id')),
+            nt_zone_record_log_id => scalar($q->param('nt_zone_record_log_id'))
         );
     }
     else {
         $action = 'Edit';
         $zone_record = $nt_obj->get_zone_record(
-            nt_group_id       => $q->param('nt_group_id'),
-            nt_zone_id        => $q->param('nt_zone_id'),
-            nt_zone_record_id => $q->param('nt_zone_record_id')
+            nt_group_id       => scalar($q->param('nt_group_id')),
+            nt_zone_id        => scalar($q->param('nt_zone_id')),
+            nt_zone_record_id => scalar($q->param('nt_zone_record_id'))
         );
     }
 
@@ -1413,7 +1413,7 @@ sub display_edit_zone {
 
     # get list of available nameservers
     my $ns_tree = $nt_obj->get_usable_nameservers(
-        nt_group_id => $q->param('nt_group_id'),
+        nt_group_id => scalar($q->param('nt_group_id')),
     );
 
     if ( @{ $ns_tree->{'nameservers'} } == 0 ) {

--- a/client/htdocs/zone_record_log.cgi
+++ b/client/htdocs/zone_record_log.cgi
@@ -53,18 +53,18 @@ sub display {
     );
 
     my $zone = $nt_obj->get_zone(
-        nt_group_id => $q->param('nt_group_id'),
-        nt_zone_id  => $q->param('nt_zone_id')
+        nt_group_id => scalar($q->param('nt_group_id')),
+        nt_zone_id  => scalar($q->param('nt_zone_id'))
     );
     $q->param( 'nt_group_id', $zone->{'nt_group_id'} );
 
     my $level = $nt_obj->display_group_tree(
         $user,
         $user->{'nt_group_id'},
-        $q->param('nt_group_id'), 0
+        scalar($q->param('nt_group_id')), 0
     );
 
-    $nt_obj->display_zone_list_options( $user, $q->param('nt_group_id'),
+    $nt_obj->display_zone_list_options( $user, scalar($q->param('nt_group_id')),
         $level, 0 );
     $nt_obj->display_zone_options( $user, $zone, $level + 1, 0 );
 
@@ -118,7 +118,7 @@ sub display_log {
         \@req_fields )
         if $q->param('edit_search');
 
-    my %params = ( map { $_, $q->param($_) } @req_fields );
+    my %params = ( map { $_, scalar($q->param($_)) } @req_fields );
     my %sort_fields;
     $nt_obj->prepare_search_params( $q, \%labels, \%params, \%sort_fields,
         $NicToolClient::page_length );
@@ -133,7 +133,7 @@ sub display_log {
 
     my @state_fields;
     foreach ( @{ $nt_obj->paging_fields } ) {
-        push( @state_fields, "$_=" . $q->escape( $q->param($_) ) )
+        push( @state_fields, "$_=" . $q->escape( scalar($q->param($_)) ) )
             if ( $q->param($_) );
     }
 

--- a/client/htdocs/zones.cgi
+++ b/client/htdocs/zones.cgi
@@ -94,7 +94,7 @@ sub print_zone_request_form {
         $q->popup_menu(
         -name    => 'action',
         -values  => [@actions],
-        -default => $q->param('action')
+        -default => scalar($q->param('action'))
         ),
         qq{   </td>
   <td class="right">New IP:</td>
@@ -102,7 +102,7 @@ sub print_zone_request_form {
         $q->textfield(
         -name  => 'newip',
         -size  => 15,
-        -value => $q->param('newip')
+        -value => scalar($q->param('newip'))
         ),
         qq{
   </td>
@@ -118,7 +118,7 @@ sub print_zone_request_form {
         $q->textfield(
         -name  => 'mailip',
         -size  => 15,
-        -value => $q->param('mailip')
+        -value => scalar($q->param('mailip'))
         ),
   qq{<br>(if different than new) </td>
  </tr>
@@ -135,7 +135,7 @@ sub print_zone_request_form {
  <tr class="light_grey_bg">
   <td>Zones:</td>
   <td colspan="2"> <textarea name="zone_list" rows="10" cols="40"> },
-        $q->param('zone_list'), qq{ </textarea></td>
+        $q->multi_param('zone_list'), qq{ </textarea></td>
   <td>A zone is also known as a domain name.<br>The same rules apply.<br>
 	<br>This is a zone: example.com<br><br>This is NOT: www.example.com
   </td>
@@ -193,7 +193,7 @@ sub zone_add {
         mailaddr    => "hostmaster.$zone.",
         description => "batch created",
         zone        => $zone,
-        nameservers => join( ',', $q->param('nameservers') ),
+        nameservers => join( ',', $q->multi_param('nameservers') ),
     );
     foreach my $s ( qw/ refresh retry expire minimum ttl serial nt_group_id / ) {
         $zone_vars{$s} = $vars{$s};
@@ -216,10 +216,10 @@ sub zone_add {
         $nt->zone_record_template(
             {   zone       => $zone,
                 nt_zone_id => $r->{'nt_zone_id'},
-                template   => $q->param('template'),
-                newip      => $q->param('newip'),
-                mailip     => $q->param('mailip'),
-                debug      => $q->param('debug')
+                template   => scalar($q->param('template')),
+                newip      => scalar($q->param('newip')),
+                mailip     => scalar($q->param('mailip')),
+                debug      => scalar($q->param('debug'))
             }
         )
     );
@@ -271,7 +271,7 @@ sub setup_http_vars {
     my @fields
         = qw(nt_group_id action newip nameservers mailip template do_reverse debug);
     foreach (@fields) { $data{$_} = $q->param($_) }
-    $data{'nameservers'} = join( ',', $q->param('nameservers') );
+    $data{'nameservers'} = join( ',', $q->multi_param('nameservers') );
 
     $data{'ttl'}     = $NicToolClient::default_zone_ttl     || 86400;
     $data{'refresh'} = $NicToolClient::default_zone_refresh || 16384;

--- a/client/lib/NicToolClient.pm
+++ b/client/lib/NicToolClient.pm
@@ -80,8 +80,8 @@ sub login_user {
 
     return $server_obj->send_request(
         action   => "login",
-        username => $q->param('username'),
-        password => $q->param('password')
+        username => scalar($q->param('username')),
+        password => scalar($q->param('password'))
     );
 }
 
@@ -526,7 +526,7 @@ sub prepare_search_params {
                     $params->{ $_ . '_inclusive' }
                         = $q->param( $_ . '_inclusive' );
                     $params->{'search_query'}
-                        .= ' ' . uc( $q->param( $_ . '_inclusive' ) ) . ' ';
+                        .= ' ' . uc( scalar($q->param( $_ . '_inclusive' )) ) . ' ';
                 }
 
                 $params->{ $_ . '_field' }  = $q->param( $_ . '_field' );
@@ -534,7 +534,7 @@ sub prepare_search_params {
                 $params->{ $_ . '_value' }  = $q->param( $_ . '_value' );
 
                 $params->{'search_query'}
-                    .= $field_labels->{ $q->param( $_ . '_field' ) } . ' '
+                    .= $field_labels->{ scalar($q->param( $_ . '_field' )) } . ' '
                     . $q->param( $_ . '_option' ) . " '"
                     . $q->param( $_ . '_value' ) . "'";
             }
@@ -544,9 +544,9 @@ sub prepare_search_params {
     if ( $q->param('change_sortorder') || $params->{'Search'} ) {
         foreach ( 1 .. 3 ) {
             if ( $q->param( $_ . '_sortfield' ) ne '--' ) {
-                $sort_fields->{ $q->param( $_ . '_sortfield' ) } = {
+                $sort_fields->{ scalar($q->param( $_ . '_sortfield' )) } = {
                     'order' => $_,
-                    'mod'   => $q->param( $_ . '_sortmod' )
+                    'mod'   => scalar($q->param( $_ . '_sortmod' ))
                 };
 
                 $params->{'Sort'} = 1;
@@ -590,7 +590,7 @@ sub display_search_rows {
         next if $_ eq 'limit';
         next if $_ eq 'page';
 
-        push( @state_vars, "$_=" . $q->escape( $q->param($_) ) ) if $q->param($_);
+        push( @state_vars, "$_=" . $q->escape( scalar($q->param($_)) ) ) if $q->param($_);
     }
 
     print qq[
@@ -684,7 +684,7 @@ sub display_search_rows {
         next if $_ eq 'edit_sortorder';
         next if ! $q->param($_);
 
-        push @state_vars, "$_=" . $q->escape( $q->param($_) );
+        push @state_vars, "$_=" . $q->escape( scalar($q->param($_)) );
     }
 
     $state_string = join( '&amp;', @state_vars );
@@ -693,7 +693,7 @@ sub display_search_rows {
     my $browse_all = '<li class=first>';
     if ( $params->{'search_query'} ne 'ALL' ) {
         my $state_map = join( '&amp;',
-            map( "$_=" . $q->escape( $q->param($_) ), @$state_fields ) );
+            map( "$_=" . $q->escape( scalar($q->param($_)) ), @$state_fields ) );
         $state_map .= "&amp;$morestr" if $morestr;
         $browse_all .= qq[<a href="$cgi_name?$state_map">Browse All</a></li>
   <li>];
@@ -915,17 +915,17 @@ sub display_group_list {
     $q->param( 'nt_group_id', $user->{'nt_group_id'} )
         if ! $q->param('nt_group_id');
 
-    my $group = $self->get_group( nt_group_id => $q->param('nt_group_id') );
+    my $group = $self->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
 
     if ( ! $group->{'has_children'} ) {
         print qq[<span class="center" style="color:red;"><strong>Group $group->{'name'} has no sub-groups!</strong></span>];
         $q->param( 'nt_group_id', $group->{'parent_group_id'} );
-        $group = $self->get_group( nt_group_id => $q->param('nt_group_id') );
+        $group = $self->get_group( nt_group_id => scalar($q->param('nt_group_id')) );
     }
     my $include_subgroups = $group->{'has_children'} ? 'sub-groups' : undef;
 
     my %params = (
-        nt_group_id    => $q->param('nt_group_id'),
+        nt_group_id    => scalar($q->param('nt_group_id')),
         start_group_id => $user->{'nt_group_id'}
     );
 
@@ -959,7 +959,7 @@ sub display_group_list {
     my @state_fields;
     foreach ( @{ $self->paging_fields } ) {
         next if ! $q->param($_);
-        push @state_fields, "$_=" . $q->escape( $q->param($_) );
+        push @state_fields, "$_=" . $q->escape( scalar($q->param($_)) );
     }
     print qq[
 <div id="groupListHeadline" class="dark_grey_bg side_pad">
@@ -975,7 +975,7 @@ sub display_group_list {
     print $q->start_form( -action => $cgi, -method => 'POST', -name => 'new' ),
         $q->hidden(
             -name     => 'obj_list',
-            -value    => join( ',', $q->param('obj_list') ),
+            -value    => join( ',', $q->multi_param('obj_list') ),
             -override => 1
         );
 
@@ -1058,8 +1058,8 @@ sub redirect_from_log {
 
     if ( $q->param('object') eq 'zone' ) {
         my $obj = $self->get_zone(
-            nt_group_id => $q->param('nt_group_id'),
-            nt_zone_id  => $q->param('obj_id')
+            nt_group_id => scalar($q->param('nt_group_id')),
+            nt_zone_id  => scalar($q->param('obj_id'))
         );
 
         return $obj if  $obj->{'error_code'} != 200;
@@ -1071,8 +1071,8 @@ sub redirect_from_log {
     };
     if ( $q->param('object') eq 'nameserver' ) {
         my $obj = $self->get_nameserver(
-            nt_group_id      => $q->param('nt_group_id'),
-            nt_nameserver_id => $q->param('obj_id')
+            nt_group_id      => scalar($q->param('nt_group_id')),
+            nt_nameserver_id => scalar($q->param('obj_id'))
         );
 
         return $obj if $obj->{'error_code'} != 200;
@@ -1091,8 +1091,8 @@ sub redirect_from_log {
     };
     if ( $q->param('object') eq 'user' ) {
         my $obj = $self->get_user(
-            nt_group_id => $q->param('nt_group_id'),
-            nt_user_id  => $q->param('obj_id')
+            nt_group_id => scalar($q->param('nt_group_id')),
+            nt_user_id  => scalar($q->param('obj_id'))
         );
 
         return $obj if $obj->{'error_code'} != 200;
@@ -1109,7 +1109,7 @@ sub redirect_from_log {
         return;
     };
     if ( $q->param('object') eq 'zone_record' ) {
-        my $obj = $self->get_zone_record( nt_zone_record_id => $q->param('obj_id') );
+        my $obj = $self->get_zone_record( nt_zone_record_id => scalar($q->param('obj_id')) );
 
         return $obj if $obj->{'error_code'} != 200;
         return {
@@ -1126,7 +1126,7 @@ sub redirect_from_log {
         return;
     };
     if ( $q->param('object') eq 'group' ) {
-        my $obj = $self->get_group( nt_group_id => $q->param('obj_id') );
+        my $obj = $self->get_group( nt_group_id => scalar($q->param('obj_id')) );
 
         return $obj if $obj->{'error_code'} != 200;
 


### PR DESCRIPTION
The apache logs contains complaints from CGI->param about insecure calls (called in list context).

Each potentially dangerous call is either replaced with CGI->multi_param(),
or is surrounded with scalar(): scalar(CGI->param()), depending on the context.

The NicToolClient code contains 435 calls to CGI->param, so these
changes were created by a script to ensure no calls got missed.

Fixes #

Changes proposed in this pull request:
- 
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
