### PR TITLE
TinyDNS import: Correct a bug in commit 8fb20cb02

### DIFF
--- a/server/lib/NicToolServer/Import/Base.pm
+++ b/server/lib/NicToolServer/Import/Base.pm
@@ -140,7 +140,7 @@ sub nt_create_record {
     );
 
     my $rr_address = $p{address};
-    if ($p{type} !~ /NAPTR|A|TXT/) {
+    if ($p{type} !~ /^(:?NAPTR|A|TXT)$/) {
         $rr_address = lc $p{address};
     }
 


### PR DESCRIPTION
TinyDNS import: Correct a bug in commit 8fb20cb02

The new regexp dealing with lowercasing of the address
field is missing a ^...$ anchor pair, otherwise all
records with a type name containing 'NAPTR', 'A' or
'TXT' are excluded from address field lowercasing.

Only 'A' is relevant and hits CNAME, SOA, AAAA and others.