### PR TITLE
TinyDNS import: Append '.' to SOA mname and rname if missing

### DIFF
--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -225,6 +225,10 @@ sub zr_soa {
     my ( $zone, $mname, $rname, $serial, $refresh, $retry, $expire, $min, $ttl, $timestamp, $location )
         = split(':', $r);
 
+    # TinyDNS auto-appends the trailing dot if missing
+    $mname .= '.' if '.' ne substr($mname, -1, 1);
+    $rname .= '.' if '.' ne substr($rname, -1, 1);
+
     my $zid = $self->nt_get_zone_id( zone => $zone );
     if ( $zid ) {
         print "zid: $zid\n";


### PR DESCRIPTION
TinyDNS import: Append '.' to SOA mname and rname if missing

TinyDNS does this.