### PR TITLE
TinyDNS import: Improve handling of TXT and SPF generic records

### DIFF
--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -465,10 +465,10 @@ sub unescape_packed_hex {
     #    A 128 bit IPv6 address is encoded in the data portion of an AAAA
     #    resource record in network byte order (high-order byte first).
 
-    # convert any octals to ASCII, then unpacks to hex chars
+    # convert any octals to ASCII, then unpack to hex chars
     $str = unpack 'H*', $self->unescape_octal($str);
 
-    # inserts : after each 4 char set
+    # insert : after each 4 char set
     return join(':', unpack("(a4)*", $str));
 };
 

--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -266,14 +266,33 @@ sub zr_generic {
     $r or die;
     print "Generic : $r\n";
     my ( $fqdn, $n, $rdata, $ttl, $timestamp, $location ) = split ':', $r;
-    return $self->zr_spf(  $r ) if $n == 99;
-    return $self->zr_aaaa( $r ) if $n == 28;
-    return $self->zr_srv( $r )  if $n == 33;
-    if ($n == 16) {
-        $r =~ s/:16:\\[\d]{3,}/:/;
-        return $self->zr_txt( $r );
-    };
+    return $self->zr_spf(  $r )    if $n == 99;
+    return $self->zr_aaaa( $r )    if $n == 28;
+    return $self->zr_srv( $r )     if $n == 33;
+    return $self->zr_gen_txt( $r ) if $n == 16;
     die "oops, no generic support for record type $n in $fqdn\n";
+}
+
+sub zr_gen_txt {
+    my $self = shift;
+    my $r = shift or die;
+
+    print "TXT : $r\n";
+    my ( $fqdn, $n, $rdata, $ttl, $timestamp, $location ) = split(':', $r);
+
+    my ($zone_id, $host) = $self->get_zone_id( $fqdn );
+
+    $rdata = $self->unpack_txt( $rdata );
+
+    $self->nt_create_record(
+        zone_id => $zone_id,
+        type    => 'TXT',
+        name    => $host,
+        address => $rdata,
+        defined $ttl       ? ( ttl       => $ttl       ) : (),
+        defined $timestamp ? ( timestamp => $timestamp ) : (),
+        defined $location  ? ( location  => $location  ) : (),
+    );
 }
 
 sub zr_spf {
@@ -390,6 +409,29 @@ sub unpack_domain {
         }
     }
     die "domain name unpack failed\n";
+}
+
+sub unpack_txt {
+    my $self = shift;
+    my $rdata = shift or die;
+
+    # Gen type 16 (TXT) rdata contains one or more strings of between 1 and
+    # 127 bytes (inclusive, after unescape), each preceeded by a length byte.
+    # Any byte (length and string bytes) *can* be octal escaped,
+    # but doesn't *have* to be if it's printable ascii (except
+    # colon ':' and backslash '\', which must always be escaped).
+
+    # Unescape everything (length and string bytes), then
+    # build the TXT string one element (1-127 bytes) at a time
+    my $raw = $self->unescape_octal( $rdata );
+    $rdata = ''; # Reset for string build
+    while (length $raw) {
+        my $len = ord(substr($raw,0,1,'')); # Length byte
+        die "Zero length element in TXT rdata ?\n" unless $len;
+        $rdata .= substr($raw,0,$len,''); # String (1..127 bytes)
+    }
+
+    return $rdata;
 }
 
 sub unescape_octal {

--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -304,11 +304,15 @@ sub zr_spf {
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
 
+    # DNS RRtype 99 (SPF) and RRtype 16 (TXT) uses the same rdata format.
+    # TinyDNS gen type :16: and :99: records are identical, except for the type.
+    $rdata = $self->unpack_txt( $rdata );
+
     $self->nt_create_record(
         zone_id => $zone_id,
         type    => 'SPF',
         name    => $host,
-        address => $self->unescape_octal( $rdata ),
+        address => $rdata,
         defined $ttl       ? ( ttl       => $ttl       ) : (),
         defined $timestamp ? ( timestamp => $timestamp ) : (),
         defined $location  ? ( location  => $location  ) : (),

--- a/server/t/25_import_tinydns.t
+++ b/server/t/25_import_tinydns.t
@@ -47,6 +47,7 @@ foreach my $test ( @$genericTests ) {
 
 test_unescape_octal();
 test_unescape_packed_hex();
+test_unpack_txt();
 
 done_testing();
 
@@ -77,5 +78,21 @@ sub test_unescape_packed_hex {
     foreach my $hex ( sort keys %packed_hex ) {
         my $r = $tinydns->unescape_packed_hex( $hex );
         cmp_ok($r, 'eq', $packed_hex{$hex}, "unescape_packed_hex, $hex");
+    };
+}
+
+sub test_unpack_txt {
+
+    my %packed_txt = (
+        # Multi-string test with unescaped length bytes
+        '*v=spf1 mx ip4\072192.168.128.111 ip4\072192.168.!174.60 ip4\072192.168.174.62 ip4\072192'.168.108.35 ip4\072192.168.109.44 ip4\072192.\156168.191.0/25 ip4\072192.168.92.15 ip4\072192.168.92.200 ip4\072192.168.162.0/24 include\072spf.protection.outlook.com -all' =>
+            'v=spf1 mx ip4:192.168.128.111 ip4:192.168.174.60 ip4:192.168.174.62 ip4:192.168.108.35 ip4:192.168.109.44 ip4:192.168.191.0/25 ip4:192.168.92.15 ip4:192.168.92.200 ip4:192.168.162.0/24 include:spf.protection.outlook.com -all',
+        # Stress some earlier implementations: Octal escaped length byte followed by digits
+        '\003007' => '007',
+    );
+
+    foreach my $txt ( sort keys %packed_txt ) {
+        my $r = $tinydns->unpack_txt( $txt );
+        cmp_ok($r, 'eq', $packed_txt{$txt}, "unpack_txt, $txt");
     };
 }

--- a/server/t/25_import_tinydns.t
+++ b/server/t/25_import_tinydns.t
@@ -85,7 +85,7 @@ sub test_unpack_txt {
 
     my %packed_txt = (
         # Multi-string test with unescaped length bytes
-        '*v=spf1 mx ip4\072192.168.128.111 ip4\072192.168.!174.60 ip4\072192.168.174.62 ip4\072192'.168.108.35 ip4\072192.168.109.44 ip4\072192.\156168.191.0/25 ip4\072192.168.92.15 ip4\072192.168.92.200 ip4\072192.168.162.0/24 include\072spf.protection.outlook.com -all' =>
+        '*v=spf1 mx ip4\072192.168.128.111 ip4\072192.168.!174.60 ip4\072192.168.174.62 ip4\072192\'.168.108.35 ip4\072192.168.109.44 ip4\072192.\156168.191.0/25 ip4\072192.168.92.15 ip4\072192.168.92.200 ip4\072192.168.162.0/24 include\072spf.protection.outlook.com -all' =>
             'v=spf1 mx ip4:192.168.128.111 ip4:192.168.174.60 ip4:192.168.174.62 ip4:192.168.108.35 ip4:192.168.109.44 ip4:192.168.191.0/25 ip4:192.168.92.15 ip4:192.168.92.200 ip4:192.168.162.0/24 include:spf.protection.outlook.com -all',
         # Stress some earlier implementations: Octal escaped length byte followed by digits
         '\003007' => '007',


### PR DESCRIPTION
The length byte(s) doesn't have to be octal escaped if
printable ascii (except colon ':' and backslash '\').

A TXT record can contain multiple strings of 1 to 127 bytes,
each with a preceding length byte (octal escaped or not).

Checklist:
- [ ] docs updated
- [ x] tests updated
