### PR TITLE
Allow NS and DS records in parent zone

### DIFF
--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -199,7 +199,7 @@ sub _name_collision {
     while ( my $name = pop @tocheck ) {
 
         #warn "checking if exists $name";
-        if ( $self->zone_exists( $name, 0 ) ) {
+        if ( $self->zone_exists( $name, 0 ) and $data->{type} ne 'NS' and $data->{type} ne 'DS') {
             $self->error( 'name',
                 "Cannot create/edit Record '$data->{name}' in zone '$z->{zone}': it conflicts with existing zone '$name'."
             );


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Allows registering NS and DS records in parent zone
  (see discussion titled "Registering NS-record in parent zone" in mailing list (list@nictool.com)
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
