### PR TITLE
Missing () pair in regexp

### DIFF
--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -310,7 +310,7 @@ sub _valid_address_chars {
     return if $data->{type} =~ /^TXT|SPF$/;
 
     my $invalid_chars = $self->get_invalid_chars( $data->{type}, 'address', $zone_text );
-    if ( $data->{address} =~ m/$invalid_chars/g ) {
+    if ( $data->{address} =~ m/($invalid_chars)/g ) {
         $self->error('address', "invalid character in record address -- $1");
     };
 }


### PR DESCRIPTION
$1 must get set, otherwise sub _valid_address_chars will always return
"invalid character in record address -- " (w/o the offending char).

Fixes #

Changes proposed in this pull request:
- 
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
