### PR TITLE
Zone import: Report reason on rejected records

### DIFF
--- a/server/bin/nt_import.pl
+++ b/server/bin/nt_import.pl
@@ -58,7 +58,16 @@ warn Dumper($nt->result->{store}) if $verbose;
 $nti->group_id( $group_id );
 
 print "\nStarting import using: $filename\n";
-$nti->import_records($filename);
+# Catch and report fatal import errors
+eval { $nti->import_records($filename); }
+if ($@) {
+    print STDERR $@; # Write die() string (unchanged) on STDERR
+    # Compress message to one line for STDOUT
+    my $msg = $@;
+    chomp $msg;
+    $msg =~ s/\n/ /g;
+    print "FATAL   : $msg\n";
+}
 
 exit 0;
 

--- a/server/lib/NicToolServer/Import/BIND.pm
+++ b/server/lib/NicToolServer/Import/BIND.pm
@@ -88,7 +88,7 @@ sub zr_ns {
 
     my $address = lc $rr->nsdname;
     $address .= '.' if substr($address, -1, 1) ne '.';
-    print 'NS : ' . $rr->name . "\t$address\n";
+    print 'NS      : ' . $rr->name . "\t$address\n";
 
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
@@ -105,7 +105,7 @@ sub zr_a {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "A : " . $rr->name . "\t" . $rr->address . "\n";
+    print "A       : " . $rr->name . "\t" . $rr->address . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -121,7 +121,7 @@ sub zr_mx {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "MX : " . $rr->name . "\t" . $rr->exchange . "\n";
+    print "MX      : " . $rr->name . "\t" . $rr->exchange . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -138,7 +138,7 @@ sub zr_txt {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "TXT : " . $rr->name . "\t" . $rr->txtdata . "\n";
+    print "TXT     : " . $rr->name . "\t" . $rr->txtdata . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -154,7 +154,7 @@ sub zr_cname {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "CNAME : ".$rr->name."\t".$rr->cname."\n";
+    print "CNAME   : ".$rr->name."\t".$rr->cname."\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -170,7 +170,7 @@ sub zr_spf {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "SPF : " . $rr->name . "\t" . $rr->txtdata . "\n";
+    print "SPF     : " . $rr->name . "\t" . $rr->txtdata . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -186,7 +186,7 @@ sub zr_aaaa {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "AAAA : " . $rr->name . "\t" . $rr->address . "\n";
+    print "AAAA    : " . $rr->name . "\t" . $rr->address . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -202,7 +202,7 @@ sub zr_srv {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "SRV : " . $rr->name . "\t" . $rr->target . "\n";
+    print "SRV     : " . $rr->name . "\t" . $rr->target . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -221,7 +221,7 @@ sub zr_loc {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "LOC : " . $rr->name . "\n";
+    print "LOC     : " . $rr->name . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -237,7 +237,7 @@ sub zr_dname {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "DNAME : ".$rr->name."\t".$rr->target."\n";
+    print "DNAME   : ".$rr->name."\t".$rr->target."\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -253,7 +253,7 @@ sub zr_sshfp {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "SSHFP : " . $rr->name . "\t" . $rr->fp . "\n";
+    print "SSHFP   : " . $rr->name . "\t" . $rr->fp . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -271,7 +271,7 @@ sub zr_naptr {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "NAPTR : " . $rr->name . "\t" . $rr->service . "\n";
+    print "NAPTR   : " . $rr->name . "\t" . $rr->service . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -290,7 +290,7 @@ sub zr_ptr {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "PTR : " . $rr->name . "\t" . $rr->ptrdname . "\n";
+    print "PTR     : " . $rr->name . "\t" . $rr->ptrdname . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(
@@ -306,7 +306,7 @@ sub zr_ipseckey {
     my ($self, $rr, $zone) = @_;
     $rr or die;
 
-    print "IPSECKEY : " . $rr->name . "\t" . $rr->gateway . "\n";
+    print "IPSECKEY: " . $rr->name . "\t" . $rr->gateway . "\n";
     my ($zone_id, $host) = $self->get_zone_id( $rr->name, $zone );
 
     $self->nt_create_record(

--- a/server/lib/NicToolServer/Import/BIND.pm
+++ b/server/lib/NicToolServer/Import/BIND.pm
@@ -56,7 +56,12 @@ sub import_zone {
     while (my $rr = $zonefile->read) {
         my $method = 'zr_' . lc $rr->type;
         print "$method\n";
-        $self->$method( $rr, $zone );
+        my $err = $self->$method( $rr, $zone );
+        # Report errors from nt_create_{zone,record}
+        if (ref $err && $err->{error_code} != 200) {
+            printf "ERROR   : %s: %s ( %s )\n",
+                $err->{error_code}, $err->{error_desc}, $err->{error_msg};
+        }
         Time::HiRes::sleep 0.1;
     };
 };

--- a/server/lib/NicToolServer/Import/tinydns.pm
+++ b/server/lib/NicToolServer/Import/tinydns.pm
@@ -102,7 +102,7 @@ sub zr_a {
     my $self = shift;
     my $r = shift or die;
 
-    print "A  : $r\n";
+    print "A       : $r\n";
     my ( $fqdn, $ip, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -122,7 +122,7 @@ sub zr_cname {
     my $self = shift;
     my $r = shift or die;
 
-    print "CNAME: $r\n";
+    print "CNAME   : $r\n";
     my ( $fqdn, $addr, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -142,7 +142,7 @@ sub zr_mx {
     my $self = shift;
     my $r = shift or die;
 
-    print "MX : $r\n";
+    print "MX      : $r\n";
     my ( $fqdn, $ip, $addr, $distance, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -163,7 +163,7 @@ sub zr_txt {
     my $self = shift;
     my $r = shift or die;
 
-    print "TXT: $r\n";
+    print "TXT     : $r\n";
     my ( $fqdn, $addr, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -183,7 +183,7 @@ sub zr_ns {
     my $self = shift;
     my $r = shift or die;
 
-    print "NS : $r\n";
+    print "NS      : $r\n";
     my ( $fqdn, $ip, $addr, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -203,7 +203,7 @@ sub zr_ptr {
     my $self = shift;
     my $r = shift or die;
 
-    print "PTR: $r\n";
+    print "PTR     : $r\n";
     my ( $fqdn, $addr, $ttl, $timestamp, $location ) = split(':', $r);
     my ($zone_id, $host);
     eval { ($zone_id, $host) = $self->get_zone_id( $fqdn ) };
@@ -233,7 +233,7 @@ sub zr_soa {
     my $self = shift;
     my $r = shift or die;
 
-    print "SOA: $r\n";
+    print "SOA     : $r\n";
     my ( $zone, $mname, $rname, $serial, $refresh, $retry, $expire, $min, $ttl, $timestamp, $location )
         = split(':', $r);
 
@@ -277,7 +277,7 @@ sub zr_gen_txt {
     my $self = shift;
     my $r = shift or die;
 
-    print "TXT : $r\n";
+    print "TXT     : $r\n";
     my ( $fqdn, $n, $rdata, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -299,7 +299,7 @@ sub zr_spf {
     my $self = shift;
     my $r = shift or die;
 
-    print "SPF : $r\n";
+    print "SPF     : $r\n";
     my ( $fqdn, $n, $rdata, $ttl, $timestamp, $location ) = split(':', $r);
 
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
@@ -323,7 +323,7 @@ sub zr_aaaa {
     my $self = shift;
     my $r = shift or die;
 
-    print "AAAA : $r\n";
+    print "AAAA    : $r\n";
     my ($fqdn, $n, $rdata, $ttl, $timestamp, $location) = split(':', $r);
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
 
@@ -365,7 +365,7 @@ sub zr_srv {
     my ($self, $r) = @_;
     $r or die "missing record";
 
-    print "SRV : $r\n";
+    print "SRV     : $r\n";
     my ($fqdn, $n, $rdata, $ttl, $timestamp, $location) = split ':', $r;
     my ($zone_id, $host) = $self->get_zone_id( $fqdn );
 


### PR DESCRIPTION
Catch and report fatal errors during import.
Also, if the server (nt_create_*) rejects a zone or record, it should be reported.

One possible usage:

(Reset log file)
$ >/log/dir/import.log

(Import the zones)
$ cd /zone/files/dir
$ for zone in * ; do nt_import.pl $zone >>/log/dir/import.log ; done

(Check the result)
$ cd /log/dir

(Count Records (RRtypes), Errors and Fatals for a quick overview)
$ cut -d: -f1 import.log | sort | uniq -c

(List errors from nt_create_{zone,record}, each with the offending record)
$ grep -B1 ^ERROR import.log

(List fatal import errors (dies), each with the offender)
$ grep -B1 ^FATAL import.log

Fixes #

Changes proposed in this pull request:
- Catch and report fatal errors in nt_import.pl, to both STDERR (die message) and STDOUT.
The message on STDOUT is consistent and easy to recognize, reducing the risk of overlooking something.
- Report errors from server on unimportable records, also in an easily recognizable format.
- Align the "<type> : <record>" output lines (easier on the eyes).

Checklist:
- [ ] docs updated
- [ ] tests updated
