### PR TITLE
Set charset to utf-8 on the frameset and the login page

### DIFF
--- a/client/htdocs/index.cgi
+++ b/client/htdocs/index.cgi
@@ -67,6 +67,9 @@ sub display_frameset {
     my ( $nt_obj, $data ) = @_;
 
     $nt_obj->set_cookie( $data->{nt_user_session} ); 
+
+    my $q = $nt_obj->{'CGI'};
+    print $q->header (-charset=>"utf-8");
  
     $nt_obj->parse_template(
         $NicToolClient::frameset_template,

--- a/client/htdocs/index.cgi
+++ b/client/htdocs/index.cgi
@@ -68,8 +68,7 @@ sub display_frameset {
 
     $nt_obj->set_cookie( $data->{nt_user_session} ); 
 
-    my $q = $nt_obj->{'CGI'};
-    print $q->header (-charset=>"utf-8");
+    print $nt_obj->{'CGI'}->header (-charset=>"utf-8");
  
     $nt_obj->parse_template(
         $NicToolClient::frameset_template,

--- a/client/lib/NicToolClient.pm
+++ b/client/lib/NicToolClient.pm
@@ -112,8 +112,7 @@ sub display_login {
         $message = $error;
     };
 
-    my $q = $self->{'CGI'};
-    print $q->header (-charset=>"utf-8");
+    print $nt_obj->{'CGI'}->header (-charset=>"utf-8");
 
     $self->parse_template( $NicToolClient::login_template, 'message' => $message);
 }

--- a/client/lib/NicToolClient.pm
+++ b/client/lib/NicToolClient.pm
@@ -112,6 +112,9 @@ sub display_login {
         $message = $error;
     };
 
+    my $q = $self->{'CGI'};
+    print $q->header (-charset=>"utf-8");
+
     $self->parse_template( $NicToolClient::login_template, 'message' => $message);
 }
 


### PR DESCRIPTION
The Login page needs to be tagged as utf-8 if it contains UTF-8 chars.
For completeness, also tag the frameset as utf-8.
