### PR TITLE
Send Session Cookie only if secure (HTTPS), remove cookie on logout

### DIFF
--- a/client/lib/NicToolClient.pm
+++ b/client/lib/NicToolClient.pm
@@ -154,6 +154,7 @@ sub set_cookie {
         -name    => 'NicTool',
         -value   => $value,
         -expires => '+1M',
+        -secure  => 1,
     );
 
     print $q->header( -cookie => $cookie );
@@ -162,13 +163,13 @@ sub set_cookie {
 sub expire_cookie {
     my $self = shift;
     my $q = shift || $self->{'CGI'};
-    my $value = shift || undef;
 
     my $cookie = $q->cookie(
         -name    => 'NicTool',
-        -value   => $value,
+        -value   => '',
         -expires => '-1d',
         -path    => '/',
+        -secure  => 1,
     );
     print $q->header( -cookie => $cookie );
 };


### PR DESCRIPTION
The Session Cookie should only be sent via HTTPS, so set the -secure flag on all ->cookie() calls.

On logout, remove the cookie entirely from the browser by sending
an expired cookie (as before), but with an empty value.

Without this change, the cookie is kept in the browser, and an extra
cookie without a name (but with the cookie value intact) is created;
seen with firefox on a Debian system.
