### PR TITLE
Dynect delete

### DIFF
--- a/server/Changes
+++ b/server/Changes
@@ -13,6 +13,8 @@ Revision history for NicToolServer
     * expand UTF support to cover all UTF8 characters (requires MySQL 5.5+)
         * change table encoding from utf8 (3 bits) to utf8mb4 (4 bits)
     * Exports: split long SPF records into 255 byte strings
+    * Export/Dyn: more robust handling of zone deletions, that could
+      result in a new zone with the same name getting unpublished.
 
 2.34    2017.03.13
 

--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -436,6 +436,7 @@ sub get_ns_zones {
           query_result  => { type => BOOLEAN, optional => 1 },
           deleted       => { type => BOOLEAN, optional => 1, default => 0 },
           publish_ts    => { type => BOOLEAN, optional => 1, default => 0 },
+          zone          => { type => SCALAR,  optional => 1 },
         },
     );
 
@@ -462,6 +463,11 @@ sub get_ns_zones {
         push @args, $self->{ns_id};
     }
 
+    if ( $p{zone} ) {
+        $sql .= " AND z.zone =?";
+        push @args, $p{zone};
+    }
+
     if ( $p{publish_ts} ) {
         $sql .= " AND z.last_modified > z.last_publish";
     }
@@ -483,19 +489,6 @@ sub get_ns_zones {
     if (scalar @descrs) { $descr_human .= join(', ', @descrs) . ' '; }
     $self->elog( "retrieved " . scalar @$r . "${descr_human}zones" );
     return $r;
-}
-
-sub zone_exists {
-    my $self = shift;
-    my %p = validate( @_, {
-        zone    => { type => SCALAR },
-        deleted => { type => BOOLEAN, optional => 1, default => 0 },
-    });
-
-    return scalar $self->exec_query(
-        "SELECT nt_zone_id FROM nt_zone WHERE z.deleted=? AND zone=?",
-        [ $p{deleted}, $p{zone} ]
-    );
 }
 
 sub get_ns_records {

--- a/server/lib/NicToolServer/Export/DynECT.pm
+++ b/server/lib/NicToolServer/Export/DynECT.pm
@@ -54,17 +54,14 @@ sub export_db {
         if ($self->{nte}->in_export_list($zone)) {
             $self->{nte}->elog("$zone recreated, skipping delete");
             next;
-        };
-        if (!$self->api_get("Zone/$zone/")) {   # zone not published on Dyn
-            next;
-        };
-
-        # don't delete if the zone exists in undeleted state
-        if ($self->{nte}->zone_exists(zone => $zone, deleted=>0)) {
+        }
+        if ($self->{nte}->get_ns_zones(zone => $zone, deleted=>0)) {
             $self->{nte}->touch_publish_ts($zone, 1);
             next;
         }
-
+        if (!$self->api_get("Zone/$zone/")) {   # zone not published on Dyn
+            next;
+        }
         if ($self->api_delete("Zone/$zone/")) {
             $self->{nte}->touch_publish_ts($zone, 1);
             $self->{nte}->elog("deleted $zone");

--- a/server/lib/NicToolServer/Export/DynECT.pm
+++ b/server/lib/NicToolServer/Export/DynECT.pm
@@ -58,7 +58,15 @@ sub export_db {
         if (!$self->api_get("Zone/$zone/")) {   # zone not published on Dyn
             next;
         };
+
+        # don't delete if the zone exists in undeleted state
+        if ($self->{nte}->zone_exists(zone => $zone, deleted=>0)) {
+            $self->{nte}->touch_publish_ts($zone, 1);
+            next;
+        }
+
         if ($self->api_delete("Zone/$zone/")) {
+            $self->{nte}->touch_publish_ts($zone, 1);
             $self->{nte}->elog("deleted $zone");
             $self->{nte}{zones_deleted}{$zone} = 1;
         }
@@ -74,9 +82,9 @@ sub export_db {
 
 sub add_zonefile {
     my ($self, $zone, $zone_str) = @_;
-# https://help.dynect.net/upload-zone-file-api/
-# TODO: check size of zone_str, and if larger than 1MB, split into multiple
-# requests.
+    # https://help.dynect.net/upload-zone-file-api/
+    # TODO: check size of zone_str, and if larger than 1MB, split into multiple
+    # requests.
     return $self->api_add("ZoneFile/$zone/", { file => $zone_str });
 };
 
@@ -140,11 +148,11 @@ sub get_zone_record {
 sub get_node_list {
     my ($self, $zone) = @_;
 
-# returns a list like this:
-#   'simerson.net',
-#   '_dmarc.simerson.net',
-#   'mar2013._domainkey.simerson.net',
-#   .....
+    # returns a list like this:
+    #   'simerson.net',
+    #   '_dmarc.simerson.net',
+    #   'mar2013._domainkey.simerson.net',
+    #   .....
 
     return $self->api_get("NodeList/$zone/");
 }
@@ -152,11 +160,11 @@ sub get_node_list {
 sub get_all_records {
     my ($self, $zone) = @_;
 
-# returns a list like this:
-#   '/REST/CNAMERecord/simerson.net/www.simerson.net/112104837',
-#   '/REST/LOCRecord/simerson.net/loc.home.simerson.net/112104878',
-#   '/REST/SOARecord/simerson.net/simerson.net/112104833',
-#   '/REST/MXRecord/simerson.net/simerson.net/112104836',
+    # returns a list like this:
+    #   '/REST/CNAMERecord/simerson.net/www.simerson.net/112104837',
+    #   '/REST/LOCRecord/simerson.net/loc.home.simerson.net/112104878',
+    #   '/REST/SOARecord/simerson.net/simerson.net/112104833',
+    #   '/REST/MXRecord/simerson.net/simerson.net/112104836',
 
     return $self->api_get("AllRecord/$zone/");
 }
@@ -275,13 +283,13 @@ sub remove_dyn_ns {
     }
 
     foreach my $ns_uri ( @{ $api_r->{data}} ) {
-# '/REST/NSRecord/simerson.net/simerson.net/112014785'
+        # '/REST/NSRecord/simerson.net/simerson.net/112014785'
         my $id = (split(/\//, $ns_uri))[-1];
-#       $self->{nte}->elog("id: $id");
+        # $self->{nte}->elog("id: $id");
         my $api_r2 = $self->get_zone_record('NS', $zone, $zone, $id);
         $self->{nte}->elog( Dumper($api_r2));
-# check $api_r2, if zone ends with dynect.net, remove it
-       #$self->api_delete("NSRecord/$zone/$zone/$id/");
+        # check $api_r2, if zone ends with dynect.net, remove it
+        #$self->api_delete("NSRecord/$zone/$zone/$id/");
     }
 };
 
@@ -306,10 +314,10 @@ sub new_session {
         return 0;
     }
 
-# {"status": "success", "data": {"token": "k4sLb+YE5B.....", "version": "3.5.7"}, "job_id": 916926679, "msgs": [{"INFO": "login: Login successful", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}';
+    # {"status": "success", "data": {"token": "k4sLb+YE5B.....", "version": "3.5.7"}, "job_id": 916926679, "msgs": [{"INFO": "login: Login successful", "SOURCE": "BLL", "ERR_CD": null, "LVL": "INFO"}]}';
 
     $self->{token} = $json->decode($res->content)->{data}{token};
-#   $self->{nte}->elog("token: $self->{token}");
+    #   $self->{nte}->elog("token: $self->{token}");
     return $self->{token};
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- after deleting a zone, update the last_publish timestamp
- fixes a problem where if a deleted zone and a undeleted zone of the same name existed, the undeleted zone could trigger the published undeleted zone to be deleted from Dyn.
    - b/c last_publish ts wasn't being updated after original zone delete
- add a check before deleting a zone. If the zone exists in undeleted state, skip deletion.
