### PR TITLE
fix equality test, restoring duplicate record prevention

### DIFF
--- a/server/lib/NicToolServer/Zone/Record.pm
+++ b/server/lib/NicToolServer/Zone/Record.pm
@@ -277,7 +277,7 @@ sub log_zone_record {
 
     my @g_columns = qw/ nt_user_id timestamp action object object_id log_entry_id title description /;
     $col_string = join(',', @g_columns);
-    @values = map( $data->{$_}, @g_columns );
+    @values = map { $data->{$_} } @g_columns;
     $self->exec_query( "INSERT INTO nt_user_global_log($col_string) VALUES(??)", \@values );
 }
 

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -118,7 +118,7 @@ sub _duplicate_record {
     # AAAA records are stored in DB in expanded notation. Expand the request
     # addr so duplicate detection works #160
     my $address = $data->{address};
-    if ($data->{type} == 'AAAA') {
+    if ($data->{type} eq 'AAAA') {
         $address = Net::IP::ip_expand_address($data->{address},6);
     }
 


### PR DESCRIPTION
fixed #185

(someone just remembered that perl doesn't use `==` for a string comparison operator)