### PR TITLE
a couple small changes for NSD exports

### DIFF
--- a/server/lib/NicToolServer/Export.pm
+++ b/server/lib/NicToolServer/Export.pm
@@ -679,7 +679,7 @@ sub load_export_class {
         require NicToolServer::Export::BIND::nsupdate;
         $self->{export_class} = NicToolServer::Export::BIND::nsupdate->new( $self );
     }
-    elsif ( $self->{export_format} eq 'NSD' ) {
+    elsif ( $self->{export_format} eq 'nsd' || $self->{export_format} eq 'NSD' ) {
         require NicToolServer::Export::NSD;
         $self->{export_class} = NicToolServer::Export::NSD->new( $self );
     }

--- a/server/lib/NicToolServer/Export/NSD.pm
+++ b/server/lib/NicToolServer/Export/NSD.pm
@@ -61,13 +61,13 @@ sub write_makefile {
 
 # NSD v4
 compile: $exportdir/nsd.nictool.conf
-\t/bin/true
+\ttest 1
 
 remote: $exportdir
 \trsync -az --delete $exportdir/ $remote_login\@$address:$datadir/
 
 restart: $exportdir
-\tssh $remote_login\@$address nsd-control reconfig && nsd-control reload
+\tssh $remote_login\@$address "nsd-control reconfig && nsd-control reload"
 
 EO_MAKE
 ;


### PR DESCRIPTION
- permit export format to be 'nsd', in addition to 'NSD'
- send both nsd-control commands to remote host