### PR TITLE
Add hint for Debian 9: cpanm is provided by package cpanminus

### DIFF
--- a/server/bin/nt_install_deps.pl
+++ b/server/bin/nt_install_deps.pl
@@ -12,7 +12,7 @@ my $apps = [
     { app => 'gettext'       , info => {}, },
     { app => 'gmake'         , info => { yum  => 'make', apt => 'make' }, },
     { app => 'rsync'         , info => { }, },
-    { app => 'cpanm'         , info => { }, },
+    { app => 'cpanm'         , info => { apt => 'cpanminus' }, },
 ];
 
 $EUID == 0 or do {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a hint that on Debian 9, /bin/cpanm is provided by package cpanminus
