### PR TITLE
Fix check for "Issuer critical" field in the CAA record sanity check.

### DIFF
--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -99,7 +99,9 @@ sub _valid_ttl {
 
     my @same_type = grep { $_->{type} eq $data->{type} } @$collisions;
     if (scalar @same_type && grep { $_->{ttl} != $data->{ttl} } @same_type) {
-        $self->error('ttl', "RRs with identical Name and Type must have identical TTL: RFC 2181");
+	# RRs with identical Name and type must have identical TTL: RFC 2181
+	# Just make it so by applying TTL update to all records in RRset
+	map { $_->{ttl} = $data->{ttl} } @same_type;
     }
 }
 

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -576,7 +576,7 @@ sub _valid_caa {
     my $tag = $data->{other};
     my $value = $data->{address};
 
-    if ($crit != 0 && $crit != 128) {
+    if (!defined($crit) || ($crit != 0 && $crit != 128)) {
 	$self->error('weight',
 		     "Critical flag must be either 0 or 128, see RFC 6844");
     }

--- a/server/lib/NicToolServer/Zone/Record/Sanity.pm
+++ b/server/lib/NicToolServer/Zone/Record/Sanity.pm
@@ -101,7 +101,11 @@ sub _valid_ttl {
     if (scalar @same_type && grep { $_->{ttl} != $data->{ttl} } @same_type) {
 	# RRs with identical Name and type must have identical TTL: RFC 2181
 	# Just make it so by applying TTL update to all records in RRset
-	map { $_->{ttl} = $data->{ttl} } @same_type;
+	map { 
+	    $_->{ttl} = $data->{ttl};
+	    # Push that update to the DB as well(!)
+	    $self->SUPER::edit_zone_record($_);
+	} @same_type;
     }
 }
 

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -439,7 +439,7 @@ sub doit {
 		ttl => 86400);
 	    my $zrid = $id->get('nt_zone_record_id');
 	    my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	    $id[$i] = $id;
+	    $id[$i] = $zrid;
 	    $zr[$i++] = $zr;
 	}
 
@@ -448,8 +448,8 @@ sub doit {
 	is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
 	# Cleanup after us...
 	foreach (@id) {
-	    $res = $user->delete_zone_record(
-		nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	    $res = $user->delete_zone_record( nt_zone_record_id => $_ );
+	    noerrok($res) or die "Could not delete test record $_";
 	}
     }
 

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,7 +428,7 @@ sub doit {
     }
 
     # TTL update of RRset
-    my(@zr);
+    my(@zr, @id);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
 	my $id = $zone1->new_zone_record(
@@ -438,6 +438,7 @@ sub doit {
 	    ttl => 86400);
 	my $zrid = $id->get('nt_zone_record_id');
 	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	$id[$i] = $id;
 	$zr[$i++] = $zr;
     }
 
@@ -445,7 +446,7 @@ sub doit {
     # Test that the update has been propagated to the whole RRset
     is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
     # Cleanup after us...
-    foreach (@zr) {
+    foreach (@ids) {
 	$res = $user->delete_zone_record(
 	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
     }

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -429,7 +429,7 @@ sub doit {
 
     # TTL update of RRset
     
-    my(@zrs);
+    my(@zr);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
 	my $id = $zone1->new_zone_record(
@@ -439,7 +439,7 @@ sub doit {
 	    ttl => 86400);
 	my $zrid = $id->get('nt_zone_record_id');
 	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	$zrs[$i++] = $zr;
+	$zr[$i++] = $zr;
     }
 
     $res = $zr[0]->edit_zone_record( ttl => 6000 );

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -427,6 +427,26 @@ sub doit {
         }
     }
 
+    # TTL update of RRset
+    
+    my(@zrs);
+    my($i) = 0;
+    foreach ('1.2.3.4', '2.3.4.5') {
+	my $id = $zone1->new_zone_record(
+	    name => "rrsetname",
+	    address => $_,
+	    type => 'A',
+	    ttl => 86400);
+	my $zrid = $id->get('nt_zone_record_id');
+	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	$zrs[$i++] = $zr;
+    }
+
+    $res = $zr[0]->edit_zone_record( ttl => 6000 );
+    # Test that the update has been propagated to the whole RRset
+    is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+
+
     ####################
     # success tests    #
     ####################

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,27 +428,29 @@ sub doit {
     }
 
     # TTL update of RRset
-    my(@zr, @id);
-    my($i) = 0;
-    foreach ('1.2.3.4', '2.3.4.5') {
-	my $id = $zone1->new_zone_record(
-	    name => "rrsetname",
-	    address => $_,
-	    type => 'A',
-	    ttl => 86400);
-	my $zrid = $id->get('nt_zone_record_id');
-	my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
-	$id[$i] = $id;
-	$zr[$i++] = $zr;
-    }
+    {
+        my(@zr, @id);
+	my($i) = 0;
+	foreach ('1.2.3.4', '2.3.4.5') {
+	    my $id = $zone1->new_zone_record(
+		name => "rrsetname",
+		address => $_,
+		type => 'A',
+		ttl => 86400);
+	    my $zrid = $id->get('nt_zone_record_id');
+	    my $zr = $user->get_zone_record( nt_zone_record_id => $zrid );
+	    $id[$i] = $id;
+	    $zr[$i++] = $zr;
+	}
 
-    $res = $zr[0]->edit_zone_record( ttl => 6000 );
-    # Test that the update has been propagated to the whole RRset
-    is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
-    # Cleanup after us...
-    foreach (@ids) {
-	$res = $user->delete_zone_record(
-	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	$res = $zr[0]->edit_zone_record( ttl => 6000 );
+	# Test that the update has been propagated to the whole RRset
+	is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+	# Cleanup after us...
+	foreach (@id) {
+	    $res = $user->delete_zone_record(
+		nt_zone_record_id => $_->{'nt_zone_record_id'} );
+	}
     }
 
 

--- a/server/t/12_records.t
+++ b/server/t/12_records.t
@@ -428,7 +428,6 @@ sub doit {
     }
 
     # TTL update of RRset
-    
     my(@zr);
     my($i) = 0;
     foreach ('1.2.3.4', '2.3.4.5') {
@@ -445,6 +444,11 @@ sub doit {
     $res = $zr[0]->edit_zone_record( ttl => 6000 );
     # Test that the update has been propagated to the whole RRset
     is ($zr[0]->get('ttl'), $zr[1]->get('ttl'));
+    # Cleanup after us...
+    foreach (@zr) {
+	$res = $user->delete_zone_record(
+	    nt_zone_record_id => $_->{'nt_zone_record_id'} );
+    }
 
 
     ####################


### PR DESCRIPTION
Changes proposed in this pull request:
- This adds a required explicit check for undefined (unset) value in the "Issuer critical"
field in the CAA record.

Checklist:
- [ ] docs updated
- [ ] tests updated