### PR TITLE
Insist that the replacement be specified for NAPTR.

### DIFF
--- a/client/htdocs/nt-script.js
+++ b/client/htdocs/nt-script.js
@@ -218,6 +218,8 @@ function setFormRRTypeNAPTR() {
   $('input#address').attr('placeholder','"" "" "/urn:cid:.+@([^\\.]+\\.)(.*)$/\\2/i"');
 
   $('td#description_label').text('Replacement');
+  $('input#description').attr('placeholder','Replacement domain or empty string');
+  $('input#description').attr('required','required');
 }
 
 function setFormRRTypeLOC() {


### PR DESCRIPTION
Put up a hint that it's a domain name or the empty string.
With a completely empty field, zone file export to BIND will
fail with a warning that "$replace" is undefined, and the
resulting zone file will fail to load with a syntax error.

Changes proposed in this pull request:
- Add guidance for "replacement" field in NAPTR record
- Insist that the "replacement" field in NAPTR is non-empty in the web UI