### PR TITLE
filters out empty query parameters for edit_record

### DIFF
--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -697,6 +697,7 @@ sub display_zone_records_edit {
             address weight priority other ttl description deleted location timestamp);
     my %data;
     foreach my $x (@fields) {
+	next if $q->param($x) eq "";
         $data{$x} = $q->param($x);
     }
     my $error = $nt_obj->edit_zone_record(%data);


### PR DESCRIPTION
mariadb 10.3.15 enforce column formats more strict. It is better
to have no field as an empty field.

Fixes #232 
