### PR TITLE
description field should not filtered out

### DIFF
--- a/client/htdocs/zone.cgi
+++ b/client/htdocs/zone.cgi
@@ -697,7 +697,7 @@ sub display_zone_records_edit {
             address weight priority other ttl description deleted location timestamp);
     my %data;
     foreach my $x (@fields) {
-        next if $q->param($x) eq '';
+        next if $q->param($x) eq '' and $x ne 'description';
         $data{$x} = $q->param($x);
     }
     my $error = $nt_obj->edit_zone_record(%data);


### PR DESCRIPTION
Pull request introduced a bug. The description field
can be empty to delete a description.

Fixes #239 

