### PR TITLE
import/bind: strip trailing dot from zone name

### DIFF
--- a/server/lib/NicToolServer/Import/BIND.pm
+++ b/server/lib/NicToolServer/Import/BIND.pm
@@ -50,6 +50,7 @@ sub import_records {
 sub import_zone {
     my ($self, $zone, $file) = @_;
 
+    $zone =~ s/\.$//; #remove trailing dot
     print "zone: $zone \tfrom\t$file\n";
 
     my $zonefile = Net::DNS::ZoneFile->new($file, $zone );


### PR DESCRIPTION
from @ryskaj

Fixes #131 
