### PR TITLE
Do caseless matching of zone name when converting to relative name.

### DIFF
--- a/server/api/contrib/zone2nic.pl
+++ b/server/api/contrib/zone2nic.pl
@@ -274,7 +274,7 @@ foreach my $zone ( @zones ) {
 
             # Turn name from fqdn back to hostname
             my $name = $rr->name;
-            $name =~ s/\.?$zone\.?//;
+            $name =~ s/\.?$zone\.?//i;
             $name = '@' if( $name eq "" );
 
             if( $rr->type eq "A" || $rr->type eq "AAAA" ) {


### PR DESCRIPTION
Changes proposed in this pull request:
- The contrib script zone2nic.pl should do caseless matching against the zone name when converting an absolute domain name to a relative domain name, so that you don't end up with the zone name twice at the end of certain domain names.