### PR TITLE
Extended create_table.pl with database type (options: mysql, MariaDB)

### DIFF
--- a/dist/docker/debian/web/conf/nt_vars
+++ b/dist/docker/debian/web/conf/nt_vars
@@ -1,3 +1,4 @@
+DB_TYPE="mysql"
 DB_HOSTNAME="changeme"
 DB_ROOT_PASSWORD="changeme"
 NICTOOL_DB_NAME="changeme"

--- a/dist/docker/debian/web/conf/nt_vars
+++ b/dist/docker/debian/web/conf/nt_vars
@@ -1,4 +1,4 @@
-DB_TYPE="mysql"
+DB_ENGINE="mysql"
 DB_HOSTNAME="changeme"
 DB_ROOT_PASSWORD="changeme"
 NICTOOL_DB_NAME="changeme"

--- a/server/sql/create_tables.pl
+++ b/server/sql/create_tables.pl
@@ -27,7 +27,7 @@ $|++;
 GetOptions(
     'test'                          => \my $test_run,
     'environment'                   => \my $environment,
-    'db-type=s'                     => \my $db_type,
+    'db-engine=s'                   => \my $db_engine,
     'db-hostname=s'                 => \my $db_hostname,
     'db-root-password=s'            => \my $db_root_password,
     'nictool-db-name=s'             => \my $nictool_db_name,
@@ -38,7 +38,7 @@ GetOptions(
     'help' => sub { HelpMessage(0) },
 ) or HelpMessage(1);
 
-my ($dbh, $db_host, $db_type) = get_dbh();
+my ($dbh, $db_host, $db_engine) = get_dbh();
 
 print "
 #########################################################################
@@ -122,7 +122,7 @@ print qq{\n
 Beginning table creation.
 If any of the information you entered is incorrect, press Control-C now!
 -------------------------
-DATABASE DSN:  $db_type://$db_user:******\@$db_host/$db
+DATABASE DSN:  $db_engine://$db_user:******\@$db_host/$db
 host: $db_host
 db  : $db
 user: $db_user
@@ -194,13 +194,13 @@ sub get_dbh {
     my $db_host = undef;
 
     if ($environment) {
-        $db_type = undef;
-        die "DB_TYPE not set!!!\n" unless $ENV{DB_TYPE};
-        $db_type = $ENV{DB_TYPE};
-    } elsif ($db_type) {
-        $db_type = $db_type;
+        $db_engine = undef;
+        die "DB_ENGINE not set!!!\n" unless $ENV{DB_ENGINE};
+        $db_engine = $ENV{DB_ENGINE};
+    } elsif ($db_engine) {
+        $db_engine = $db_engine;
     } else {
-        $db_type = answer("database type", 'mysql');
+        $db_engine = answer("database engine", 'mysql');
     }
 
     if ($environment) {
@@ -229,12 +229,12 @@ sub get_dbh {
     print "\n";
 
     return if $test_run;
-    my $dbh = DBI->connect("dbi:$db_type:host=$db_host", "root", $db_root_pw, {
+    my $dbh = DBI->connect("dbi:$db_engine:host=$db_host", "root", $db_root_pw, {
             ChopBlanks => 1,
         })
         or die $DBI::errstr;
 
-    return ($dbh, $db_host, $db_type);
+    return ($dbh, $db_host, $db_engine);
 }
 
 sub answer {
@@ -340,12 +340,12 @@ create_tables.pl - configure the NicTool database.
   --test                        Perform a test run.
 
   --environment                 Use environment variables to set up the database. These
-                                are as follows: DB_TYPE, DB_HOSTNAME, DB_ROOT_PASSWORD,
+                                are as follows: DB_ENGINE, DB_HOSTNAME, DB_ROOT_PASSWORD,
                                 NICTOOL_DB_NAME, NICTOOL_DB_USER, NICTOOL_DB_USER_PASSWORD,
                                 ROOT_USER_EMAIL, ROOT_USER_PASSWORD. If this flag is
                                 present, the remaining arguments below are ignored.
 
-  --db-type                     The MySQL database type (mysql or MariaDB).
+  --db-engine                   The MySQL database engine (mysql or MariaDB).
   --db-hostname                 The MySQL database hostname or IP address to connect to.
   --db-root-password            The MySQL root user password.
   --nictool-db-name             The name of the NicTool database. Defaults to 'nictool'.

--- a/server/sql/create_tables.pl
+++ b/server/sql/create_tables.pl
@@ -27,6 +27,7 @@ $|++;
 GetOptions(
     'test'                          => \my $test_run,
     'environment'                   => \my $environment,
+    'db-type=s'                     => \my $db_type,
     'db-hostname=s'                 => \my $db_hostname,
     'db-root-password=s'            => \my $db_root_password,
     'nictool-db-name=s'             => \my $nictool_db_name,
@@ -37,7 +38,7 @@ GetOptions(
     'help' => sub { HelpMessage(0) },
 ) or HelpMessage(1);
 
-my ($dbh, $db_host) = get_dbh();
+my ($dbh, $db_host, $db_type) = get_dbh();
 
 print "
 #########################################################################
@@ -121,7 +122,7 @@ print qq{\n
 Beginning table creation.
 If any of the information you entered is incorrect, press Control-C now!
 -------------------------
-DATABASE DSN:  mysql://$db_user:******\@$db_host/$db
+DATABASE DSN:  $db_type://$db_user:******\@$db_host/$db
 host: $db_host
 db  : $db
 user: $db_user
@@ -193,6 +194,16 @@ sub get_dbh {
     my $db_host = undef;
 
     if ($environment) {
+        $db_type = undef;
+        die "DB_TYPE not set!!!\n" unless $ENV{DB_TYPE};
+        $db_type = $ENV{DB_TYPE};
+    } elsif ($db_type) {
+        $db_type = $db_type;
+    } else {
+        $db_type = answer("database type", 'mysql');
+    }
+
+    if ($environment) {
         $db_hostname = undef;
         die "DB_HOSTNAME not set!!!\n" unless $ENV{DB_HOSTNAME};
         $db_host = $ENV{DB_HOSTNAME};
@@ -218,12 +229,12 @@ sub get_dbh {
     print "\n";
 
     return if $test_run;
-    my $dbh = DBI->connect("dbi:mysql:host=$db_host", "root", $db_root_pw, {
+    my $dbh = DBI->connect("dbi:$db_type:host=$db_host", "root", $db_root_pw, {
             ChopBlanks => 1,
         })
         or die $DBI::errstr;
 
-    return ($dbh, $db_host);
+    return ($dbh, $db_host, $db_type);
 }
 
 sub answer {
@@ -329,11 +340,12 @@ create_tables.pl - configure the NicTool database.
   --test                        Perform a test run.
 
   --environment                 Use environment variables to set up the database. These
-                                are as follows: DB_HOSTNAME, DB_ROOT_PASSWORD,
+                                are as follows: DB_TYPE, DB_HOSTNAME, DB_ROOT_PASSWORD,
                                 NICTOOL_DB_NAME, NICTOOL_DB_USER, NICTOOL_DB_USER_PASSWORD,
                                 ROOT_USER_EMAIL, ROOT_USER_PASSWORD. If this flag is
                                 present, the remaining arguments below are ignored.
 
+  --db-type                     The MySQL database type (mysql or MariaDB).
   --db-hostname                 The MySQL database hostname or IP address to connect to.
   --db-root-password            The MySQL root user password.
   --nictool-db-name             The name of the NicTool database. Defaults to 'nictool'.
@@ -344,6 +356,6 @@ create_tables.pl - configure the NicTool database.
 
 =head1 VERSION
 
-2.33
+2.33.2
 
 =cut


### PR DESCRIPTION
Improves the create_tables.pl script. ! non-braking change !

The changes in this pull request prepare the base for upgrading the Dockerfile from Debian 8.8 + mysql 5.5 to Debian 10 + Mariadb. The change is a NON-braking change. 

The changes allow the database type (mysql or Mariadb) to be defined either via command line argument or environment variable. As used in the Dockerfile, the environment variable introduced is set in the nt_vars file with a default of "mysql". This should ensure a default which keeps everything running. 

I hope this change can be accepted as a first step to upgrade the Dockerfile. 

Checklist:
- [x] docs updated (help screen of the script)
- [ ] tests updated
