### PR TITLE
Removing Listen 443 frim dist/docker/debian/web/conf/nictool.conf

### DIFF
--- a/dist/docker/debian/web/conf/nictool.conf
+++ b/dist/docker/debian/web/conf/nictool.conf
@@ -6,7 +6,6 @@ PerlRequire /usr/local/nictool/client/lib/nictoolclient.conf
     Redirect / https://dns.example.net/   # change me
 </VirtualHost>
 
-Listen 443
 <VirtualHost _default_:443>
     ServerName dns.example.net            # change me
     Alias /images/ "/usr/local/nictool/client/htdocs/images/"


### PR DESCRIPTION
Changes proposed in this pull request:
- Listen 443 is already present in /etc/apache2/sites-enabled/000-default.conf and causes issues.
- apache2 reports this as "(98)Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:443"
- As of this, the Listen statement is removed in the "dist/docker/debian/web/conf/nictool.conf"

Verified with Debian 8.8 and Debian 10 container. 

Checklist:
- [ ] docs updated
- [ ] tests updated
