### PR TITLE
Improved nt_export to allow MariaDB dsn

### DIFF
--- a/server/bin/nt_export.pl
+++ b/server/bin/nt_export.pl
@@ -183,7 +183,7 @@ sub get_db_creds_from_nictoolserver_conf {
     my $contents = `cat $file`;
 
     if ( ! $dsn ) {
-        ($dsn) = $contents =~ m/['"](DBI:mysql.*?)["']/;
+        ($dsn) = $contents =~ m/['"](DBI:.*?)["']/;
     };
 
     if ( ! $db_user ) {


### PR DESCRIPTION
Changes proposed in this pull request:
- The nt_export script reads the database dsn from the nictoolserver.conf file.
-  It uses a regex that does not support MariaDB dsn stings. (match for "DBI:mysql") 
- Reduced the regex match to "DBI:" which is still unique enough  
- This change allows mysql and MariaDB dsn strings. 

Noticed the following interesting side effect. 
When connecting with mysql dsn to a mysql 5.5 the list of nsid's seems sorted. When connecting to the exact same database server using the MariaDB connector, the nsid's are not sorted (in my test 2,1,3 was the order. 
- It does not interfere with functionality as far as I can tell.

Tested with Debian 8.8 and Debian 10 container.

Checklist:
- [ ] docs updated
- [ ] tests updated
