### PR TITLE
Implemented #226 to reliably import zone data

### DIFF
--- a/dist/docker/debian/web/Dockerfile
+++ b/dist/docker/debian/web/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -rf /etc/apache2/sites-enabled/* \
 # ensure exposed 
 RUN mkdir -p /etc/nictool/ && mkdir -p /var/lib/nictool/
 
-RUN a2enmod ssl
+RUN a2enmod ssl && a2dismod mpm_event && a2enmod mpm_prefork
 
 ADD startup.sh /startup.sh
 


### PR DESCRIPTION
implementing fix suggested in  #226. 

Changes proposed in this pull request:
- changing the mpm in apache from event to prefork
- Seems to fix the issue with randomly failing zone import

Background:
Observed random errors while importing zones. The error message is always the same but the point in the import process is always different. 

    FATAL   :  ( SOAP: transport error: http://127.0.0.1:8082/soap: 500 Server closed connection without sending any data back ) at /usr/local/share/perl/5.28.1/NicToolServer/Import/Base.pm line 166, <GEN280> line 994.

A tcpdump of the API communication indicates the last request befor the error isnot answered. As the apache webserver dow not return a single packet, I assume this could be a very specific issue effecting apache itself. 

The suggested fix from #226 seems to solve that issue. So this fix is added to the Dockerfile.

Checklist:
- [ ] docs updated
- [ ] tests updated
