### PR TITLE
SQL doesn't permit empty string for INT/TIMESTAMP

### DIFF
--- a/dist/docker/debian/web/Dockerfile
+++ b/dist/docker/debian/web/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -rf /etc/apache2/sites-enabled/* \
 # ensure exposed 
 RUN mkdir -p /etc/nictool/ && mkdir -p /var/lib/nictool/
 
-RUN a2enmod ssl
+RUN a2enmod ssl && a2dismod mpm_event && a2enmod mpm_prefork
 
 ADD startup.sh /startup.sh
 

--- a/server/lib/NicToolServer/Zone/Record.pm
+++ b/server/lib/NicToolServer/Zone/Record.pm
@@ -143,7 +143,7 @@ sub edit_zone_record {
             push @values, $self->get_record_type({ type=> $data->{$c} });
         }
         elsif ( $c eq 'timestamp' || $c eq 'weight' || $c eq 'priority' ) {
-            if( ! defined $data->{$c} || $data->{$c} == '') {
+            if( $data->{$c} == '') {
                 $sql =~ s/,$//;
                 next;
             }

--- a/server/lib/NicToolServer/Zone/Record.pm
+++ b/server/lib/NicToolServer/Zone/Record.pm
@@ -143,7 +143,7 @@ sub edit_zone_record {
             push @values, $self->get_record_type({ type=> $data->{$c} });
         }
         elsif ( $c eq 'timestamp' || $c eq 'weight' || $c eq 'priority' ) {
-            if( ! $data->{$c}) {
+            if( ! defined $data->{$c} || $data->{$c} == '') {
                 $sql =~ s/,$//;
                 next;
             }


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
Fix the update query so that we will omit fields which do not need a value added, allowing the default SQL value to be applied. SQL no longer permits a string (even the empty string '') for a INT/TIMESTAMP field.

Checklist:
- [ ] docs updated
- [ ] tests updated
