### PR TITLE
Added container LDAP perl module

### DIFF
--- a/dist/docker/debian/web/Dockerfile
+++ b/dist/docker/debian/web/Dockerfile
@@ -38,6 +38,9 @@ RUN cd /usr/local/nictool/server \
       cd /usr/local/nictool/client \
       && perl bin/install_deps.pl
 
+# install Perl module for LDAP authentication
+RUN cpanm Net::LDAP
+
 # set up apache
 RUN rm -rf /etc/apache2/sites-enabled/* \
       && rm -rf /etc/apache2/sites-available/*


### PR DESCRIPTION
As the LDAP perl module is not a requirement for nictool but an add-on, the additional perl module for LDAP authentication is not added to the requirements list but as a separate statement to the Dockerfile

Changes proposed in this pull request:
- installation of Net::LDAP in the container

Checklist:
- [ ] docs updated
- [ ] tests updated
